### PR TITLE
Fix directory path to clean modules before installation

### DIFF
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -395,7 +395,11 @@ _install_driver() {
 
     echo "Installing NVIDIA driver kernel modules..."
     cd /usr/src/nvidia-${DRIVER_VERSION}
-    rm -rf /lib/modules/${KERNEL_VERSION}/video
+    if [ -d /lib/modules/${KERNEL_VERSION}/kernel/drivers/video ]; then
+        rm -rf /lib/modules/${KERNEL_VERSION}/kernel/drivers/video
+    else
+        rm -rf /lib/modules/${KERNEL_VERSION}/video
+    fi
 
     if [ "${ACCEPT_LICENSE}" = "yes" ]; then
         install_args+=("--accept-license")


### PR DESCRIPTION
After restart driver-container or host system, the container fails to install driver because old module exists. 

log:
```
ERROR: The file '/lib/modules/5.19.0-32-generic/kernel/drivers/video/nvidia.ko' already exists as part of this driver installation.
```

So I fix directory path to clean modules before driver installation.