### PR TITLE
fix: add missing rhel9 ngc ci steps

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -409,3 +409,31 @@ release:ngc-rhel8.9:
     - .dist-rhel8
   variables:
     OUT_DIST: "rhel8.9"
+
+release:ngc-rhel9.0:
+  extends:
+    - .release:ngc
+    - .dist-rhel9
+  variables:
+    OUT_DIST: "rhel9.0"
+
+release:ngc-rhel9.1:
+  extends:
+    - .release:ngc
+    - .dist-rhel9
+  variables:
+    OUT_DIST: "rhel9.1"
+
+release:ngc-rhel9.2:
+  extends:
+    - .release:ngc
+    - .dist-rhel9
+  variables:
+    OUT_DIST: "rhel9.2"
+
+release:ngc-rhel9.3:
+  extends:
+    - .release:ngc
+    - .dist-rhel9
+  variables:
+    OUT_DIST: "rhel9.3"


### PR DESCRIPTION
Hi again 👋🏻 ,

migrating this PR from Gitlab as suggested by @ArangoGutierrez.

As you're apparently planning to migrate to the main repo from Gitlab to Github (including CICD?), this PR might be obsolete at this point. Also, as already mentioned in the original PR on Gitlab which is no longer available, I'm not quite sure if the jobs/steps defined in the `.nvidia-ci.yml` are being used anywhere, as there is no direct include in the main gitlab ci file.

If it is used to build the images for NGC, this PR _should_ be adding the images for RHEL9 if I understood the setup correctly.

As said, this might be obsolete at this point, so feel free to close this PR if it is no longer required.