### PR TITLE
[rhel9] update golang version to 1.22.1

### DIFF
--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN dnf install -y git wget
 
-ENV GOLANG_VERSION=1.22.0
+ENV GOLANG_VERSION=1.22.1
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \


### PR DESCRIPTION
This fixes some CVEs recently reported from the go version used