### PR TITLE
[Ubuntu 22.04] Install gcc-12 in the driver container build phase

### DIFF
--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -93,6 +93,14 @@ WORKDIR  /drivers
 ARG PUBLIC_KEY=empty
 COPY ${PUBLIC_KEY} kernel/pubkey.x509
 
+# Install the gcc-12 package in Ubuntu 22.04 as Kernels with versions 5.19.x and 6.5.x need gcc 12.3.0 for compilation
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc-12 g++-12 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 && \
+    rm -rf /var/lib/apt/lists/*
+
+
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \


### PR DESCRIPTION
gcc-12 is needed for the more recent kernel versions - 5.19.x and 6.5.x. We have also found that gcc-12 is backwards compatible with kernels that have been compiled against gcc-11

This change is limited to Ubuntu 22.04 as `gcc-12` is not available as a package in Ubuntu 20.04