### PR TITLE
remove centos7 support, bump cuda and go versions

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -112,10 +112,6 @@ trigger-pipeline:
   variables:
     DIST: rhel9
 
-.dist-centos7:
-  variables:
-    DIST: centos7
-
 .dist-fedora36:
   variables:
     DIST: fedora36
@@ -277,13 +273,6 @@ release:staging-rhel9:
     - .dist-rhel9
   needs:
     - image-rhel9
-
-release:staging-centos7:
-  extends:
-    - .release:staging
-    - .dist-centos7
-  needs:
-    - image-centos7
 
 .release:staging-precompiled:
   stage: release

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -41,7 +41,6 @@ jobs:
           - ubuntu20.04
           - ubuntu22.04
           - rhel8
-          - centos7
           - rhel9
           - fedora36
         ispr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,11 +79,6 @@ image-rhel9:
     - .image-build-rhel9
     - .dist-rhel9
 
-image-centos7:
-  extends:
-    - .image-build
-    - .dist-centos7
-
 image-fedora36:
   extends:
     - .image-build

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -121,11 +121,6 @@ image-rhel9:
     - .dist-rhel9
     - .driver-versions-rhel9
 
-image-centos7:
-  extends:
-    - .image-pull
-    - .dist-centos7
-
 # The .scan step forms the base of the image scan operation performed before releasing
 # images.
 .scan-generic:
@@ -283,14 +278,6 @@ scan-rhel9-arm64:
   needs:
     - image-rhel9
 
-scan-centos7-amd64:
-  extends:
-    - .scan
-    - .dist-centos7
-    - .platform-amd64
-  needs:
-    - image-centos7
-
 .release:ngc-variables:
   variables:
     OUT_REGISTRY_USER: "${NGC_REGISTRY_USER}"
@@ -327,11 +314,6 @@ release:ngc-precompiled-ubuntu22.04:
   rules:
     # Only run NGC release job on scheduled pipelines
     - if: $CI_PIPELINE_SOURCE == "schedule"
-
-release:ngc-centos7:
-  extends:
-    - .release:ngc
-    - .dist-centos7
 
 release:ngc-rhcos4.9:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OUT_IMAGE_TAG = $(OUT_IMAGE_VERSION)-$(OUT_DIST)
 OUT_IMAGE = $(OUT_IMAGE_NAME):$(OUT_IMAGE_TAG)
 
 ##### Public rules #####
-DISTRIBUTIONS := ubuntu18.04 ubuntu20.04 ubuntu22.04 signed_ubuntu20.04 signed_ubuntu22.04 rhel8 rhel9 centos7 flatcar fedora36 sles15.3 precompiled_rhcos
+DISTRIBUTIONS := ubuntu18.04 ubuntu20.04 ubuntu22.04 signed_ubuntu20.04 signed_ubuntu22.04 rhel8 rhel9 flatcar fedora36 sles15.3 precompiled_rhcos
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))
 BASE_FROM := jammy focal
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))

--- a/ci/localbuild.sh
+++ b/ci/localbuild.sh
@@ -54,12 +54,6 @@ driver_container_build_ubuntu()
   driver_container_build_simple "ubuntu16.04"
 }
 
-driver_container_build_centos()
-{
-  driver_container_build_simple "centos7"
-  driver_container_build_simple "centos8"
-}
-
 driver_container_build_rhel()
 {
   driver_container_build_simple "rhel7"
@@ -118,7 +112,6 @@ ngc_push()
 
 driver_container_build_ubuntu
 driver_container_build_rhel
-driver_container_build_centos
 
 list_all_containers
 

--- a/multi-arch.mk
+++ b/multi-arch.mk
@@ -26,5 +26,4 @@ $(DRIVER_PUSH_TARGETS): push-%:
 build-ubuntu18.04%: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
 build-signed_ubuntu20.04%: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
 build-signed_ubuntu22.04%: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
-build-centos7%: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
 build-sles%: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN dnf install -y git wget
 
-ENV GOLANG_VERSION=1.22.1
+ENV GOLANG_VERSION=1.22.2
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN dnf install -y git wget
 
-ENV GOLANG_VERSION=1.22.1
+ENV GOLANG_VERSION=1.22.2
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION=1.22.1
+ENV GOLANG_VERSION=1.22.2
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION=1.22.1
+ENV GOLANG_VERSION=1.22.2
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/versions.mk
+++ b/versions.mk
@@ -15,4 +15,4 @@
 # DRIVER_VERSIONS contains latest version in all active datacenter branches
 DRIVER_VERSIONS ?= 470.239.06 535.161.08 550.54.15
 
-CUDA_VERSION := 12.3.2
+CUDA_VERSION := 12.4.1

--- a/vgpu/src/go.mod
+++ b/vgpu/src/go.mod
@@ -1,6 +1,6 @@
 module vgpu-util
 
-go 1.20
+go 1.22.2
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/vgpu/src/go.sum
+++ b/vgpu/src/go.sum
@@ -25,3 +25,4 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
As cuda version `12.4.1` is no longer available for `centos`, we remove support for centos