### PR TITLE
[ubuntu22.04] add R550 precompiled driver containers

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -84,7 +84,7 @@ trigger-pipeline:
 .driver-versions-precompiled-ubuntu22.04:
   parallel:
     matrix:
-      - DRIVER_BRANCH: [535]
+      - DRIVER_BRANCH: [535, 550]
         KERNEL_FLAVOR: [generic, nvidia, aws, azure]
 
 # Define the driver versions for jobs that can be run in parallel for rhel9

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -107,6 +107,7 @@ jobs:
       matrix:
         driver: 
           - 535
+          - 550
         flavor: 
           - generic
           - nvidia


### PR DESCRIPTION
The precompiled driver packages for R550 in ubuntu22.04 are now live

https://packages.ubuntu.com/search?suite=jammy&section=all&arch=any&keywords=linux-modules-nvidia-550-server&searchon=names