### PR TITLE
[Ubuntu 22.04] build precompiled driver containers for the oracle flavour

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -85,7 +85,7 @@ trigger-pipeline:
   parallel:
     matrix:
       - DRIVER_BRANCH: [535, 550]
-        KERNEL_FLAVOR: [generic, nvidia, aws, azure]
+        KERNEL_FLAVOR: [aws, azure, generic, nvidia, oracle]
 
 # Define the driver versions for jobs that can be run in parallel for rhel9
 .driver-versions-rhel9:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -107,11 +107,12 @@ jobs:
         driver: 
           - 535
           - 550
-        flavor: 
-          - generic
-          - nvidia
+        flavor:
           - aws
           - azure
+          - generic
+          - nvidia
+          - oracle
         ispr:
           - ${{github.event_name == 'pull_request'}}
         exclude:
@@ -121,6 +122,8 @@ jobs:
             flavor: aws
           - ispr: true
             flavor: nvidia
+          - ispr: true
+            flavor: oracle
     steps:
       - uses: actions/checkout@v4
         name: Check out code


### PR DESCRIPTION
Canonical regularly publishes. Oracle-flavoured Ubuntu precompiled nvidia driver packages. We should take advantage of this in our precompiled driver publish pipelines

[R550 Precompiled driver container for Ubuntu22.04](https://packages.ubuntu.com/search?suite=jammy&section=all&arch=any&keywords=linux-objects-nvidia-550-5.15.0-1058-oracle&searchon=names)
[R535 Precompiled driver container for Ubuntu22.04](https://packages.ubuntu.com/search?suite=jammy&section=all&arch=any&keywords=linux-objects-nvidia-530-5.15.0-1058-oracle&searchon=names)

Signed-off-by: Tariq Ibrahim <tibrahim@nvidia.com>