### PR TITLE
Add libnvidia-nscq for Azure Linux

### DIFF
--- a/azurelinux/Dockerfile
+++ b/azurelinux/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL -o /etc/yum.repos.d/mariner-nvidia.repo \
 # Create a location to store the pre-downloaded RPMs for installation during container runtime
 RUN mkdir -p /opt/nvidia
 RUN tdnf -y --downloadonly --downloaddir=/opt/nvidia install cuda-${DRIVER_VERSION}-${KERNEL_VERSION} \
-        nvidia-fabric-manager-${DRIVER_VERSION}
+        nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_VERSION}
 
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"

--- a/azurelinux/nvidia-driver
+++ b/azurelinux/nvidia-driver
@@ -93,8 +93,8 @@ _install_driver() {
     echo "Installing the NVIDIA driver modules"
     tdnf install -y ${PACKAGE_DIR}/cuda-${DRIVER_VERSION}*${KERNEL_VERSION//-/.}*.rpm
 
-    echo "Installing the NVIDIA fabricmanager"
-    tdnf install -y ${PACKAGE_DIR}/nvidia-fabric-manager-${DRIVER_VERSION}*.rpm
+    echo "Installing the NVIDIA fabricmanager and NSCQ"
+    tdnf install -y ${PACKAGE_DIR}/nvidia-fabric-manager-${DRIVER_VERSION}*.rpm ${PACKAGE_DIR}/libnvidia-nscq-${DRIVER_VERSION}*.rpm
 }
 
 # Load the kernel modules and start persistenced.


### PR DESCRIPTION
Onboard the libnvidia-nscq RPM published by the Azure Linux team for the Azure Linux precompiled driver container