### PR TITLE
Added  '| grep "Basesystem"' to ensure only one software repo is returned for local variable in the _resolve_kernel_version function

### DIFF
--- a/sle15/nvidia-driver
+++ b/sle15/nvidia-driver
@@ -44,7 +44,7 @@ _resolve_kernel_version() {
     fi
     local version_without_flavor=$(echo ${KERNEL_VERSION} | cut -d- -f-2)
     local version=$(zypper -x se -s -t package --match-exact "kernel-devel$package_flavor"  |
-      grep "solvable "| grep $version_without_flavor | sed -e 's/.*edition="\([^"]*\).*/\1/g;s/\(.*\)\..*/\1/')
+      grep "solvable "| grep $version_without_flavor | grep "Basesystem" | sed -e 's/.*edition="\([^"]*\).*/\1/g;s/\(.*\)\..*/\1/')
 
     if [ -z "${version}" ]; then
         echo "Could not resolve Linux kernel version" >&2


### PR DESCRIPTION
I wasn't sure exactly what the local variable in the _resolve_kernel_version function
---
local version=$(zypper -x se -s -t package --match-exact "kernel-devel$package_flavor"  |
      grep "solvable "| grep $version_without_flavor | sed -e 's/.*edition="\([^"]*\).*/\1/g;s/\(.*\)\..*/\1/')
---
is trying to return. Since this script, when run against kernel version 5.14.21-150500.55.62-default, only returns the Basesystem repo, I assumed that this was the desired result.

However, when the script is run against kernel version 5.14.21-150500.55.62-default, it sometime returns the both the SLE_BCI and Basesystem repos.

I'm offering a very simple fix  of inserting a grep for "Basesystem" that can be used or can just serve as an example for a more elegant solution.

