### PR TITLE
run the sign-ngc-precompiled-job only during scheduled CI jobs

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -491,6 +491,9 @@ sign:ngc-precompiled-ubuntu22.04:
     PRECOMPILED: "true"
   needs:
     - release:ngc-precompiled-ubuntu22.04
+  rules:
+    # Only run NGC release job on scheduled pipelines
+    - if: $CI_PIPELINE_SOURCE == "schedule"
 
 sign:ngc-ubuntu-rhel-rhcos:
   extends:


### PR DESCRIPTION
This change should resolve the following errors seen when attempting to run gitlab pipelines on merge to main

```
Unable to create pipeline
'sign:ngc-precompiled-ubuntu22.04: [535, aws]' job needs 'release:ngc-precompiled-ubuntu22.04: [535, aws]' job, but 'release:ngc-precompiled-ubuntu22.04: [535, aws]' is not in any previous stage
'sign:ngc-precompiled-ubuntu22.04: [535, aws]' job needs 'release:ngc-precompiled-ubuntu22.04: [535, azure]' job, but 'release:ngc-precompiled-ubuntu22.04: [535, azure]' is not in any previous stage
'sign:ngc-precompiled-ubuntu22.04: [535, aws]' job needs 'release:ngc-precompiled-ubuntu22.04: [535, generic]' job, but 'release:ngc-precompiled-ubuntu22.04: [535, generic]' is not in any previous stage
'sign:ngc-precompiled-ubuntu22.04: [535, aws]' job needs 'release:ngc-precompiled-ubuntu22.04: [535, nvidia]' job, but 'release:ngc-precompiled-ubuntu22.04: [535, nvidia]' is not in any previous stage
'sign:ngc-precompiled-ubuntu22.04: [535, aws]' job needs 'release:ngc-precompiled-ubuntu22.04: [535, oracle]' job, but 'release:ngc-precompiled-ubuntu22.04: [535, oracle]' is not in any previous stage
...
...
```


As the `release:ngc-precompiled-ubuntu22.04` jobs are only run on triggering scheduled pipelines, the same constraints should be applied to `'sign:ngc-precompiled-ubuntu22.04`