### PR TITLE
bump golang version to 1.22.7

### DIFF
--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN dnf install -y git wget
 
-ENV GOLANG_VERSION=1.22.5
+ENV GOLANG_VERSION=1.22.7
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN dnf install -y git wget
 
-ENV GOLANG_VERSION=1.22.5
+ENV GOLANG_VERSION=1.22.7
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION=1.22.5
+ENV GOLANG_VERSION=1.22.7
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION=1.22.5
+ENV GOLANG_VERSION=1.22.7
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \


### PR DESCRIPTION
This will fix the CVE reported here: https://pkg.go.dev/vuln/GO-2024-3107