### PR TITLE
bump cuda base image versions in precompiled driver images

### DIFF
--- a/rhel8/precompiled/Dockerfile
+++ b/rhel8/precompiled/Dockerfile
@@ -49,7 +49,7 @@ RUN export KVER=$(echo ${KERNEL_VERSION} | cut -d '-' -f 1) \
         --define "driver_branch ${DRIVER_STREAM}" \
         -v -bb SPECS/kmod-nvidia.spec
 
-FROM nvcr.io/nvidia/cuda:12.5.1-base-${CUDA_DIST}
+FROM nvcr.io/nvidia/cuda:12.6.2-base-${CUDA_DIST}
 
 ARG KERNEL_VERSION=''
 ARG RHEL_VERSION=''

--- a/rhel9/precompiled/Dockerfile
+++ b/rhel9/precompiled/Dockerfile
@@ -65,7 +65,7 @@ RUN export KVER=$(echo ${KERNEL_VERSION} | cut -d '-' -f 1) \
         --define "driver_branch ${DRIVER_STREAM}" \
         -v -bb SPECS/kmod-nvidia.spec
 
-FROM nvcr.io/nvidia/cuda:12.5.1-base-${CUDA_DIST}
+FROM nvcr.io/nvidia/cuda:12.6.2-base-${CUDA_DIST}
 
 ARG BASE_URL='https://us.download.nvidia.com/tesla'
 

--- a/ubuntu20.04/precompiled/Dockerfile
+++ b/ubuntu20.04/precompiled/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubuntu20.04
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubi8
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubi8
 
 ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION

--- a/vgpu-manager/ubuntu20.04/Dockerfile
+++ b/vgpu-manager/ubuntu20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubuntu20.04
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu20.04
 
 ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION

--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.5.1-base-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04
 
 ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION


### PR DESCRIPTION
TODO: Investigate why dependabot doesn't open PRs for these