### PR TITLE
[ubuntu24.04] grant _apt user root privileges

### DIFF
--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -67,7 +67,9 @@ ADD install.sh /tmp
 RUN apt-key del 7fa2af80 && OS_ARCH=${TARGETARCH/amd64/x86_64} && OS_ARCH=${OS_ARCH/arm64/sbsa} && \
     apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${OS_ARCH}/3bf863cc.pub"
 
-RUN /tmp/install.sh depinstall
+RUN usermod -o -u 0 -g 0 _apt && \
+    /tmp/install.sh depinstall
+
 
 COPY nvidia-driver /usr/local/bin
 


### PR DESCRIPTION
This PR fixes the following warning observed when running the ubuntu24.04 gpu driver container

`W: Download is performed unsandboxed as root as file '/tmp/tmp.t07XczEtx1/linux-image-6.8.0-47-generic_6.8.0-47.47_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)`

This is consistent with the driver containers for the other OS versions