### PR TITLE
[ubuntu24.04] use KERNEL_MODULE_TYPE envar in place of OPEN_KERNEL_MODULES_ENABLED

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -15,9 +15,7 @@ NVIDIA_UVM_MODULE_PARAMS=()
 NVIDIA_MODESET_MODULE_PARAMS=()
 NVIDIA_PEERMEM_MODULE_PARAMS=()
 TARGETARCH=${TARGETARCH:?"Missing TARGETARCH env"}
-
-OPEN_KERNEL_MODULES_ENABLED=${OPEN_KERNEL_MODULES_ENABLED:-false}
-[[ "${OPEN_KERNEL_MODULES_ENABLED}" == "true" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-auto}
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -359,6 +357,12 @@ _install_driver() {
         install_args+=("--concurrency-level=${MAX_THREADS}")
     fi
 
+    if [[ "${KERNEL_MODULE_TYPE}" == "open"  || "${KERNEL_MODULE_TYPE}" == "proprietary" ]]; then
+        [[ "${KERNEL_MODULE_TYPE}" == "open" ]] && kernel_type=kernel-open || kernel_type=kernel
+        echo "Proceeding with user-specified kernel module type ${KERNEL_MODULE_TYPE}"
+        install_args+=("-m=${kernel_type}")
+    fi
+
     # Install the NVIDIA driver in one step
     sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
                     --ui=none \
@@ -374,7 +378,6 @@ _install_driver() {
                     --x-module-path=/tmp/null \
                     --x-library-path=/tmp/null \
                     --x-sysconfig-path=/tmp/null \
-                    -m="${KERNEL_TYPE}" \
                     ${install_args[@]+"${install_args[@]}"}
 }
 


### PR DESCRIPTION
With this change, the ubuntu24.04 will select the recommended kernel module type for a driver version and the gpu device. It also provides users the option to explicitly set a desired kernel module type.

~We also replace the -m flag with the --kernel-module-type as the former is deprecated. See below (taken from the nvidia-installer CLI help text)~ UPDATE: It looks like `--kernel-module-type` is a new flag and is only available from R560 onwards. So we can only add this flag after R535 and R550 are EOL'ed

```
  -M KERNEL-MODULE-TYPE, --kernel-module-type=KERNEL-MODULE-TYPE
      The type of kernel modules to build and install. Valid values are "open" and "proprietary".

  -m KERNEL-MODULE-BUILD-DIRECTORY, --kernel-module-build-directory=KERNEL-MODULE-BUILD-DIRECTORY
      Directly set the directory within the package from which to build the kernel modules. This option is deprecated; use "--kernel-module-type" instead.

```