### PR TITLE
[ubuntu24.04] only install required driver packages

### DIFF
--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -49,7 +49,10 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
     fi
 
 # update pkg cache and install pkgs for userspace driver libs
-RUN apt-get update && apt-get install -y --download-only --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server \
+RUN apt-get update && apt-get install -y --download-only --no-install-recommends \
+    nvidia-utils-${DRIVER_BRANCH}-server \
+    nvidia-compute-utils-${DRIVER_BRANCH}-server \
+    libnvidia-cfg1-${DRIVER_BRANCH}-server \
     nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 \
     libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
     rm -rf /var/lib/apt/lists/*;

--- a/ubuntu22.04/precompiled/nvidia-driver
+++ b/ubuntu22.04/precompiled/nvidia-driver
@@ -234,15 +234,11 @@ _unload_driver() {
 
 # Link and install the kernel modules from a precompiled packages
 _install_driver() {
-    # Install necessary userspace, fabric manager and libnvidia-nscq packages
-    apt-get install -y --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server
-
-    # Uninstall unnecessary packages installed as a part of the nvidia-driver-${DRIVER_BRANCH}-server package
-    apt-get purge -y \
-        libnvidia-egl-wayland1 \
-        nvidia-dkms-${DRIVER_BRANCH}-server \
-        nvidia-kernel-source-${DRIVER_BRANCH}-server \
-        xserver-xorg-video-nvidia-${DRIVER_BRANCH}-server
+    # Install necessary driver userspace packages
+    apt-get install -y --no-install-recommends \
+        nvidia-utils-${DRIVER_BRANCH}-server \
+        nvidia-compute-utils-${DRIVER_BRANCH}-server \
+        libnvidia-cfg1-${DRIVER_BRANCH}-server
 
     # Now install the precompiled kernel module packages signed by Canonical
     if [ "$OPEN_KERNEL_MODULES_ENABLED" = true ]; then

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -44,7 +44,10 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
     fi
 
 # update pkg cache and install pkgs for userspace driver libs
-RUN apt-get update && apt-get install -y --download-only --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server \
+RUN apt-get update && apt-get install -y --download-only --no-install-recommends \
+    nvidia-utils-${DRIVER_BRANCH}-server \
+    nvidia-compute-utils-${DRIVER_BRANCH}-server \
+    libnvidia-cfg1-${DRIVER_BRANCH}-server \
     nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 \
     libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
     rm -rf /var/lib/apt/lists/*;

--- a/ubuntu24.04/precompiled/nvidia-driver
+++ b/ubuntu24.04/precompiled/nvidia-driver
@@ -235,14 +235,10 @@ _unload_driver() {
 # Link and install the kernel modules from a precompiled packages
 _install_driver() {
     # Install necessary driver userspace packages
-    apt-get install -y --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server
-
-    # Uninstall unnecessary packages installed as a part of the nvidia-driver-${DRIVER_BRANCH}-server package
-    apt-get purge -y \
-        libnvidia-egl-wayland1 \
-        nvidia-dkms-${DRIVER_BRANCH}-server \
-        nvidia-kernel-source-${DRIVER_BRANCH}-server \
-        xserver-xorg-video-nvidia-${DRIVER_BRANCH}-server
+    apt-get install -y --no-install-recommends \
+        nvidia-utils-${DRIVER_BRANCH}-server \
+        nvidia-compute-utils-${DRIVER_BRANCH}-server \
+        libnvidia-cfg1-${DRIVER_BRANCH}-server
 
     # Now install the precompiled kernel module packages signed by Canonical
     if [ "$OPEN_KERNEL_MODULES_ENABLED" = true ]; then


### PR DESCRIPTION
This PR moves away from the approach of installing the driver metapackage and purging the unneeded components in favour of just installing the necessary packages to get the nvidia-driver-daemonset running.

Dpkg output after running this container
```
# dpkg -l | grep -i nvidia
ii  libnvidia-cfg1-550-server:amd64                  550.127.08-0ubuntu0.24.04.1       amd64        NVIDIA binary OpenGL/GLX configuration library
ii  libnvidia-compute-550-server:amd64               550.127.08-0ubuntu0.24.04.1       amd64        NVIDIA libcompute package
ii  linux-modules-nvidia-550-server-6.8.0-51-generic 6.8.0-51.52+1                     amd64        Linux kernel nvidia modules for version 6.8.0-51
ii  linux-objects-nvidia-550-server-6.8.0-51-generic 6.8.0-51.52+1                     amd64        Linux kernel nvidia modules for version 6.8.0-51 (objects)
ii  linux-signatures-nvidia-6.8.0-51-generic         6.8.0-51.52+1                     amd64        Linux kernel signatures for nvidia modules for version 6.8.0-51-generic
ii  nvidia-compute-utils-550-server                  550.127.08-0ubuntu0.24.04.1       amd64        NVIDIA compute utilities
ii  nvidia-firmware-550-server-550.127.08            550.127.08-0ubuntu0.24.04.1       amd64        Firmware files used by the kernel module
ii  nvidia-kernel-common-550-server                  550.127.08-0ubuntu0.24.04.1       amd64        Shared files used with the kernel module
ii  nvidia-utils-550-server                          550.127.08-0ubuntu0.24.04.1       amd64        NVIDIA Server Driver support binaries
``` 

NOTE: `libnvidia-cfg1-550-server:amd64` is needed to get `nvidia-persistenced` to run successfully. As per the syslogs the persistenced binary looks for the `libnvidia-cfg1.so1` file