### PR TITLE
Remove installation of imex pkg on Ubuntu 20.04

### DIFF
--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -87,17 +87,6 @@ RUN if [ "$DRIVER_TYPE" != "vgpu" ] && [ "$TARGETARCH" != "arm64" ]; then \
     libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
     rm -rf /var/lib/apt/lists/*; fi
 
-# Force install the imex package to workaround a dependency issue.
-# The debian packages for Ubuntu 20.04 incorrectly mark openssl >= 3
-# as a dependency of the nvidia-imex-$DRIVER_BRANCH package, even
-# though openssl is statically linked.
-RUN if [ "$DRIVER_TYPE" != "vgpu" ] && [ "$DRIVER_BRANCH" -ge "550" ]; then \
-    OS_ARCH=${TARGETARCH/amd64/x86_64} && OS_ARCH=${OS_ARCH/arm64/sbsa} && \
-    curl -fSsL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/${OS_ARCH}/nvidia-imex-${DRIVER_BRANCH}_${DRIVER_VERSION}-1_${TARGETARCH}.deb \
-        -o nvidia-imex.deb && \
-    dpkg --force-all -i nvidia-imex.deb && \
-    rm nvidia-imex.deb; fi
-
 WORKDIR  /drivers
 
 ARG PUBLIC_KEY=empty


### PR DESCRIPTION
The debian package is broken for Ubuntu 20.04 and force installing it introduced a regression. At runtime, we install some prerequisite packages, but apt fails to install them due to the unmet dependencies of the nvidia-imex package.