### PR TITLE
[ubuntu-precompiled] enable offline installation of driver packages

### DIFF
--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -48,27 +48,20 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
-# update pkg cache and install pkgs for userspace driver libs
-RUN apt-get update && apt-get install -y --download-only --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server \
-    nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 \
-    libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
-    rm -rf /var/lib/apt/lists/*;
-
 RUN if [ "$DRIVER_BRANCH" -ge "550" ]; then \
     apt-get update && \
     apt-get install -y --no-install-recommends nvidia-imex-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
     rm -rf /var/lib/apt/lists/*; fi
 
-# update pkg cache and download pkgs for driver module installation during runtime.
-# this is done to avoid shipping .ko files.
-# avoid cleaning the cache after this to retain these packages during runtime.
-RUN apt-get update && apt-get install --download-only --no-install-recommends -y linux-objects-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION} \
-    linux-signatures-nvidia-${KERNEL_VERSION} \
-    linux-modules-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION} \
-    # add support for nvidia open source driver packages during runtime
-    linux-modules-nvidia-${DRIVER_BRANCH}-server-open-${KERNEL_VERSION}
-
 COPY nvidia-driver /usr/local/bin
+
+ADD local-repo.sh /tmp
+
+RUN mkdir -p /usr/local/repos && \
+    /tmp/local-repo.sh download_driver_package_deps && \
+    /tmp/local-repo.sh build_local_apt_repo && \
+    # Remove cuda repository to avoid GPG errors
+    rm -f /etc/apt/sources.list.d/cuda*
 
 WORKDIR  /drivers
 

--- a/ubuntu22.04/precompiled/local-repo.sh
+++ b/ubuntu22.04/precompiled/local-repo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eu
+
+LOCAL_REPO_DIR=/usr/local/repos
+
+download_apt_with_dep () {
+  local package="$1"
+  apt-get download $package
+  apt-get download $(apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances $package | grep "^\w" | sort -u)
+}
+
+download_driver_package_deps () {
+  apt-get update
+  pushd ${LOCAL_REPO_DIR}
+
+  download_apt_with_dep linux-objects-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION}
+  download_apt_with_dep linux-signatures-nvidia-${KERNEL_VERSION}
+  download_apt_with_dep linux-modules-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION}
+  download_apt_with_dep linux-modules-nvidia-${DRIVER_BRANCH}-server-open-${KERNEL_VERSION}
+  download_apt_with_dep nvidia-utils-${DRIVER_BRANCH}-server
+  download_apt_with_dep nvidia-headless-no-dkms-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-decode-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-extra-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-encode-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-fbc1-${DRIVER_BRANCH}-server
+
+  apt-get download nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1
+  apt-get download libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1
+
+  ls -al .
+  popd
+}
+
+build_local_apt_repo () {
+  pushd ${LOCAL_REPO_DIR}
+  dpkg-scanpackages . /dev/null | gzip -9c | tee Packages.gz > /dev/null
+  echo "deb [trusted=yes] file:${LOCAL_REPO_DIR} ./" > /etc/apt/sources.list
+  popd
+  apt-get update
+}
+
+if [ "$1" = "download_driver_package_deps" ]; then
+  download_driver_package_deps
+elif [ "$1" = "build_local_apt_repo" ]; then
+  build_local_apt_repo
+else
+  echo "Unknown function: $1"
+  exit 1
+fi

--- a/ubuntu22.04/precompiled/nvidia-driver
+++ b/ubuntu22.04/precompiled/nvidia-driver
@@ -234,15 +234,14 @@ _unload_driver() {
 
 # Link and install the kernel modules from a precompiled packages
 _install_driver() {
-    # Install necessary userspace, fabric manager and libnvidia-nscq packages
-    apt-get install -y --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server
-
-    # Uninstall unnecessary packages installed as a part of the nvidia-driver-${DRIVER_BRANCH}-server package
-    apt-get purge -y \
-        libnvidia-egl-wayland1 \
-        nvidia-dkms-${DRIVER_BRANCH}-server \
-        nvidia-kernel-source-${DRIVER_BRANCH}-server \
-        xserver-xorg-video-nvidia-${DRIVER_BRANCH}-server
+    # Install necessary driver userspace packages
+    apt-get install -y --no-install-recommends \
+        nvidia-utils-${DRIVER_BRANCH}-server \
+        nvidia-headless-no-dkms-${DRIVER_BRANCH}-server \
+        libnvidia-decode-${DRIVER_BRANCH}-server \
+        libnvidia-extra-${DRIVER_BRANCH}-server \
+        libnvidia-encode-${DRIVER_BRANCH}-server \
+        libnvidia-fbc1-${DRIVER_BRANCH}-server
 
     # Now install the precompiled kernel module packages signed by Canonical
     if [ "$OPEN_KERNEL_MODULES_ENABLED" = true ]; then

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -43,27 +43,20 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
-# update pkg cache and install pkgs for userspace driver libs
-RUN apt-get update && apt-get install -y --download-only --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server \
-    nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 \
-    libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
-    rm -rf /var/lib/apt/lists/*;
-
 RUN if [ "$DRIVER_BRANCH" -ge "550" ]; then \
     apt-get update && \
     apt-get install -y --no-install-recommends nvidia-imex-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
     rm -rf /var/lib/apt/lists/*; fi
 
-# update pkg cache and download pkgs for driver module installation during runtime.
-# this is done to avoid shipping .ko files.
-# avoid cleaning the cache after this to retain these packages during runtime.
-RUN apt-get update && apt-get install --download-only --no-install-recommends -y linux-objects-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION} \
-    linux-signatures-nvidia-${KERNEL_VERSION} \
-    linux-modules-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION} \
-    # add support for nvidia open source driver packages during runtime
-    linux-modules-nvidia-${DRIVER_BRANCH}-server-open-${KERNEL_VERSION}
-
 COPY nvidia-driver /usr/local/bin
+
+ADD local-repo.sh /tmp
+
+RUN mkdir -p /usr/local/repos && \
+    /tmp/local-repo.sh download_driver_package_deps && \
+    /tmp/local-repo.sh build_local_apt_repo && \
+    # Remove cuda repository to avoid GPG errors
+    rm -f /etc/apt/sources.list.d/cuda* \
 
 WORKDIR  /drivers
 

--- a/ubuntu24.04/precompiled/local-repo.sh
+++ b/ubuntu24.04/precompiled/local-repo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eu
+
+LOCAL_REPO_DIR=/usr/local/repos
+
+download_apt_with_dep () {
+  local package="$1"
+  apt-get download $package
+  apt-get download $(apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances $package | grep "^\w" | sort -u)
+}
+
+download_driver_package_deps () {
+  apt-get update
+  pushd ${LOCAL_REPO_DIR}
+
+  download_apt_with_dep linux-objects-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION}
+  download_apt_with_dep linux-signatures-nvidia-${KERNEL_VERSION}
+  download_apt_with_dep linux-modules-nvidia-${DRIVER_BRANCH}-server-${KERNEL_VERSION}
+  download_apt_with_dep linux-modules-nvidia-${DRIVER_BRANCH}-server-open-${KERNEL_VERSION}
+  download_apt_with_dep nvidia-utils-${DRIVER_BRANCH}-server
+  download_apt_with_dep nvidia-headless-no-dkms-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-decode-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-extra-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-encode-${DRIVER_BRANCH}-server
+  download_apt_with_dep libnvidia-fbc1-${DRIVER_BRANCH}-server
+
+  apt-get download nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1
+  apt-get download libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1
+
+  ls -al .
+  popd
+}
+
+build_local_apt_repo () {
+  pushd ${LOCAL_REPO_DIR}
+  dpkg-scanpackages . /dev/null | gzip -9c | tee Packages.gz > /dev/null
+  echo "deb [trusted=yes] file:${LOCAL_REPO_DIR} ./" > /etc/apt/sources.list
+  popd
+  apt-get update
+}
+
+if [ "$1" = "download_driver_package_deps" ]; then
+  download_driver_package_deps
+elif [ "$1" = "build_local_apt_repo" ]; then
+  build_local_apt_repo
+else
+  echo "Unknown function: $1"
+  exit 1
+fi


### PR DESCRIPTION
This PR introduces a completely new method of installing the nvidia precompiled driver packages. 

## Motivation 
We recently discovered that our offline installs weren't exactly "offline". During the driver container run-time, the driver container was still downloading packages externally. The root cause of this was the multiple `apt-get update` calls, which would erase the previously downloaded packages from the `apt-get install -y --no-install-recommends --download-only <packages>` command.

## Summary of changes:
i) Download the packages and its dependencies using the following commands
```
apt-get download $PACKAGE
apt-get download $(apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances $PACKAGE | grep "^\w" | sort -u)
```
ii) Move to a permanent location and gzip the apt-get downloaded packages.
iii) Create a local apt package source pointing to the new directory with the downloaded packages

NOTE: In this PR, I also move away from installing the giant metapackage `nvidia-drivers-${DRIVER_VERSION}-server` and purging unneeded packages thereafter. Instead, we just install the packages that we actually need instead of worrying about any bloat

