### PR TITLE
dependabot update for nested dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
 
   - package-ecosystem: "docker"
     directories:
-      - "*"
+      - "**/*"
     open-pull-requests-limit: 15
     schedule:
       interval: "daily"


### PR DESCRIPTION
 directories:
        - "*"  

Dependabot does not support wildcard * or **/ paths in the directory field. 
docker section will fail silently 

