### PR TITLE
gomod dependabot update for nested dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     target-branch: main
-    directory: "/"
+    directories:
+      - "**/*"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"


### PR DESCRIPTION
directories: / will not work as there is no go.mod files

directories search path added for gomod