### PR TITLE
update RH OCP support matrix

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -421,6 +421,13 @@ release:ngc-rhcos4.17:
   variables:
     OUT_DIST: "rhcos4.17"
 
+release:ngc-rhcos4.18:
+  extends:
+    - .release:ngc
+    - .dist-rhel8
+  variables:
+    OUT_DIST: "rhcos4.18"
+
 release:ngc-rhel8.8:
   extends:
     - .release:ngc
@@ -545,5 +552,5 @@ sign:ngc-ubuntu-rhel-rhcos:
       VERSION: ["8.8", "8.10"]
       DRIVER_VERSION: ["535.230.02", "550.144.03", "570.124.06"]
     - SIGN_JOB_NAME: ["rhcos"]
-      VERSION: ["4.12","4.13","4.14","4.15", "4.16", "4.17"]
+      VERSION: ["4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18"]
       DRIVER_VERSION: ["535.230.02", "550.144.03", "570.124.06"]


### PR DESCRIPTION
Add OCP 4.18 as it is the newest Openshift Version.

Reference: https://access.redhat.com/support/policy/updates/openshift