### PR TITLE
Precompile kernel version fix for multiple base target

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -199,7 +199,7 @@ jobs:
           done))
           fi
           source ./tests/scripts/ci-precompiled-helpers.sh
-          KERNEL_VERSIONS=($(get_kernel_versions_to_test $BASE_TARGET KERNEL_FLAVORS[@] DRIVER_BRANCHES[@] $DIST))
+          KERNEL_VERSIONS=($(get_kernel_versions_to_test KERNEL_FLAVORS[@] DRIVER_BRANCHES[@] $DIST $LTS_KERNEL))
           if [ -z "$KERNEL_VERSIONS" ]; then
             # no new kernel release
             echo "Skipping e2e tests"

--- a/tests/scripts/ci-precompiled-helpers.sh
+++ b/tests/scripts/ci-precompiled-helpers.sh
@@ -1,18 +1,18 @@
 get_kernel_versions_to_test() {
     if [[ "$#" -ne 4 ]]; then
-	    echo " Error:$0 must be called with BASE_TARGET KERNEL_FLAVORS DRIVER_BRANCHES DIST" >&2
+	    echo " Error:$0 must be called with KERNEL_FLAVORS DRIVER_BRANCHES DIST LTS_KERNEL" >&2
 	    exit 1
     fi
 
-    local BASE_TARGET="$1"
-    local -a KERNEL_FLAVORS=("${!2}")
-    local -a DRIVER_BRANCHES=("${!3}")
-    local DIST="$4"
+    local -a KERNEL_FLAVORS=("${!1}")
+    local -a DRIVER_BRANCHES=("${!2}")
+    local DIST="$3"
+    local LTS_KERNEL="$4"
 
     kernel_versions=()
     for kernel_flavor in "${KERNEL_FLAVORS[@]}"; do
         for DRIVER_BRANCH in "${DRIVER_BRANCHES[@]}"; do
-            source ./tests/scripts/findkernelversion.sh "$BASE_TARGET" "${kernel_flavor}" "$DRIVER_BRANCH" "$DIST" >&2
+            source ./tests/scripts/findkernelversion.sh "${kernel_flavor}" "$DRIVER_BRANCH" "$DIST" "$LTS_KERNEL" >&2
             if [[ "$should_continue" == true ]]; then
                 break
             fi

--- a/tests/scripts/findkernelversion.sh
+++ b/tests/scripts/findkernelversion.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 if [[ $# -ne 4 ]]; then
-	echo " BASE_TARGET KERNEL_FLAVOR DRIVER_BRANCH DIST are required"
+	echo " KERNEL_FLAVOR DRIVER_BRANCH DIST LTS_KERNEL are required"
 	exit 1
 fi
 
-export BASE_TARGET="${1}"
-export KERNEL_FLAVOR="${2}"
-export DRIVER_BRANCH="${3}"
-export DIST="${4}"
+export KERNEL_FLAVOR="${1}"
+export DRIVER_BRANCH="${2}"
+export DIST="${3}"
+export LTS_KERNEL="${4}"
 
 export REGCTL_VERSION=v0.7.1
 mkdir -p bin
@@ -17,30 +17,20 @@ chmod a+x bin/regctl
 export PATH=$(pwd)/bin:${PATH}
 
 # calculate kernel version of latest image
-regctl image get-file ghcr.io/nvidia/driver:base-${BASE_TARGET}-${KERNEL_FLAVOR}-${DRIVER_BRANCH} /var/kernel_version.txt ./kernel_version.txt 2>/dev/null || true
-if [[ -f ./kernel_version.txt && -s ./kernel_version.txt ]]; then
-    # File exists and is not empty
-    export $(grep -oP 'KERNEL_VERSION=[^ ]+' ./kernel_version.txt)
-    rm -f kernel_version.txt
-else
-    # Define variables for artifact pattern
-    prefix="kernel-version-${DRIVER_BRANCH}-${LTS_KERNEL}"
-    suffix="${kernel_flavor}-${DIST}"
-    artifacts=$(gh api -X GET /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[].name')
-    # Use a loop or a pattern to find the matching artifact dynamically
-    for artifact in $artifacts; do
-        # TODO remove this check once nvidia avaialble
-        # currently for ubuntu24.04 kernel_flavor = nvidia-lowlatency
-        if [[ $artifact == $prefix*-$suffix ]]; then
-            gh run download --name "$artifact" --dir ./
-            tar -xf $artifact.tar 
-            rm -f $artifact.tar
-            export $(grep -oP 'KERNEL_VERSION=[^ ]+' ./kernel_version.txt)
-            rm -f kernel_version.txt
-            break
-        fi
-    done
-fi
+prefix="kernel-version-${DRIVER_BRANCH}-${LTS_KERNEL}"
+suffix="${kernel_flavor}-${DIST}"
+artifacts=$(gh api -X GET /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --paginate --jq '.artifacts[].name')
+# find the matching artifact dynamically
+for artifact in $artifacts; do
+    if [[ $artifact == $prefix*-$suffix ]]; then
+        gh run download --name "$artifact" --dir ./
+        tar -xf $artifact.tar 
+        rm -f $artifact.tar
+        export $(grep -oP 'KERNEL_VERSION=[^ ]+' ./kernel_version.txt)
+        rm -f kernel_version.txt
+        break
+    fi
+done
 
 # calculate driver tag
 status=0


### PR DESCRIPTION
_Removed downloading of kernel_version.txt from the Docker base.
Now, artifacts-based download is considered instead.
Reason: When building the base via make build-base-jammy, it now includes two LTS kernels (Ubuntu 22.04: 5.15 and 6.8). Running a parallel matrix will cause make build-base-jammy to overwrite( 5.15 and 6.8) kernel-version.txt, leading to incorrect values in matrix_values files during download with regctl in determine-e2e-test-matrix job. with regctl command we are downloading kernel_version.txt file from docker base. 
Solution: Either modify the Makefile to introduce a new command (make build-base-${base_target}-${lts_kernel}) or directly download kernel_version.txt from artifacts.
Since kernel_version... files are already being uploaded as artifacts, we now rely on those values._