### PR TITLE
USE GIT_COMMIT in container builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ $(DRIVER_BUILD_TARGETS):
 				--build-arg DRIVER_BRANCH="$(DRIVER_BRANCH)" \
 				--build-arg CUDA_VERSION="$(CUDA_VERSION)" \
 				--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
+				--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 				$(DOCKER_BUILD_ARGS) \
 				--file $(DOCKERFILE) \
 				$(CURDIR)/$(SUBDIR)

--- a/rhel10/Dockerfile
+++ b/rhel10/Dockerfile
@@ -43,6 +43,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_BRANCH
 ENV DRIVER_BRANCH=$DRIVER_BRANCH
+ARG GIT_COMMIT
 
 # Arg to indicate if driver type is either of passthrough/baremetal or vgpu
 ARG DRIVER_TYPE=passthrough
@@ -99,6 +100,7 @@ LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
 LABEL description="See summary"

--- a/rhel10/precompiled/Dockerfile
+++ b/rhel10/precompiled/Dockerfile
@@ -93,6 +93,8 @@ ARG BUILD_ARCH
 ARG TARGET_ARCH
 ENV TARGETARCH=${TARGET_ARCH}
 
+ARG GIT_COMMIT
+
 # Force using provided RHSM registration
 ENV SMDEV_CONTAINER_OFF=1
 
@@ -179,6 +181,7 @@ LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="${KERNEL_VERSION}-${OS_TAG}"
 LABEL summary="Provision the NVIDIA driver through containers"
 LABEL description="See summary"

--- a/rhel10/precompiled/Makefile
+++ b/rhel10/precompiled/Makefile
@@ -1,3 +1,5 @@
+GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")
+
 RHEL_VERSION ?= 10.0
 RHEL_VERSION_MAJOR = $(shell echo "${RHEL_VERSION}" | awk -F. '{print $$1}')
 
@@ -70,6 +72,7 @@ image: rhsm-register
 		--build-arg DRIVER_STREAM_TYPE=${DRIVER_STREAM_TYPE} \
 		--build-arg BASE_URL=${BASE_URL} \
 		--build-arg OS_TAG=${OS_TAG} \
+		--build-arg GIT_COMMIT=${GIT_COMMIT} \
 		--tag ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DRIVER_VERSION}-${KERNEL_VERSION_TAG}-${OS_TAG} \
 		--progress=plain \
 		--file ${DOCKERFILE} .

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -42,6 +42,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_BRANCH
 ENV DRIVER_BRANCH=$DRIVER_BRANCH
+ARG GIT_COMMIT
 
 # Arg to indicate if driver type is either of passthrough/baremetal or vgpu
 ARG DRIVER_TYPE=passthrough
@@ -97,6 +98,7 @@ LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
 LABEL description="See summary"

--- a/rhel8/precompiled/Dockerfile
+++ b/rhel8/precompiled/Dockerfile
@@ -67,6 +67,8 @@ ENV DRIVER_VERSION=${DRIVER_VERSION}
 ARG TARGET_ARCH=''
 ENV TARGETARCH=${TARGET_ARCH}
 
+ARG GIT_COMMIT
+
 # Force using provided RHSM registration
 ENV SMDEV_CONTAINER_OFF=1
 
@@ -146,6 +148,7 @@ LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
 LABEL description="See summary"

--- a/rhel8/precompiled/Makefile
+++ b/rhel8/precompiled/Makefile
@@ -1,4 +1,5 @@
 DOCKERFILE = Dockerfile
+GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")
 RHEL_VERSION ?= 8.6
 CUDA_VERSION ?= 12.6.0
 CUDA_DIST ?= ubi8
@@ -52,6 +53,7 @@ image: rhsm-register
 		--build-arg DRIVER_TOOLKIT_IMAGE=${DRIVER_TOOLKIT_IMAGE} \
 		--build-arg DRIVER_TYPE=${DRIVER_TYPE} \
 		--build-arg BASE_URL=${BASE_URL} \
+		--build-arg GIT_COMMIT=${GIT_COMMIT} \
 		--tag ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DRIVER_VERSION}-${KERNEL_VERSION}-${OS_TAG} \
 		--progress=plain \
 		--file ${DOCKERFILE} .

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -42,6 +42,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_BRANCH
 ENV DRIVER_BRANCH=$DRIVER_BRANCH
+ARG GIT_COMMIT
 
 # Arg to indicate if driver type is either of passthrough/baremetal or vgpu
 ARG DRIVER_TYPE=passthrough
@@ -98,6 +99,7 @@ LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
 LABEL description="See summary"

--- a/rhel9/precompiled/Dockerfile
+++ b/rhel9/precompiled/Dockerfile
@@ -93,6 +93,8 @@ ARG BUILD_ARCH
 ARG TARGET_ARCH
 ENV TARGETARCH=${TARGET_ARCH}
 
+ARG GIT_COMMIT
+
 # Force using provided RHSM registration
 ENV SMDEV_CONTAINER_OFF=1
 
@@ -179,6 +181,7 @@ LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="${KERNEL_VERSION}-${OS_TAG}"
 LABEL summary="Provision the NVIDIA driver through containers"
 LABEL description="See summary"

--- a/rhel9/precompiled/Makefile
+++ b/rhel9/precompiled/Makefile
@@ -1,3 +1,5 @@
+GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")
+
 RHEL_VERSION ?= 9.4
 RHEL_VERSION_MAJOR = $(shell echo "${RHEL_VERSION}" | awk -F. '{print $$1}')
 
@@ -70,6 +72,7 @@ image: rhsm-register
 		--build-arg DRIVER_STREAM_TYPE=${DRIVER_STREAM_TYPE} \
 		--build-arg BASE_URL=${BASE_URL} \
 		--build-arg OS_TAG=${OS_TAG} \
+		--build-arg GIT_COMMIT=${GIT_COMMIT} \
 		--tag ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DRIVER_VERSION}-${KERNEL_VERSION_TAG}-${OS_TAG} \
 		--progress=plain \
 		--file ${DOCKERFILE} .

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -50,6 +50,7 @@ ENV TARGETARCH=$TARGETARCH
 ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
+ARG GIT_COMMIT
 
 # Arg to indicate if driver type is either of passthrough(baremetal) or vgpu
 ARG DRIVER_TYPE=passthrough
@@ -106,5 +107,14 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
+
+LABEL io.k8s.display-name="NVIDIA Driver Container"
+LABEL name="NVIDIA Driver Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA driver through containers"
+LABEL description="See summary"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -15,6 +15,8 @@ ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG KERNEL_VERSION=5.15.0-116-generic
 ENV KERNEL_VERSION=$KERNEL_VERSION
 
+ARG GIT_COMMIT
+
 ENV NVIDIA_VISIBLE_DEVICES=void
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -68,5 +70,14 @@ WORKDIR  /drivers
 
 # Remove cuda repository to avoid GPG errors
 RUN rm -f /etc/apt/sources.list.d/cuda*
+
+LABEL io.k8s.display-name="NVIDIA Driver Container"
+LABEL name="NVIDIA Driver Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_BRANCH}-${KERNEL_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA driver through containers"
+LABEL description="See summary"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -50,6 +50,7 @@ ARG BASE_URL=https://us.download.nvidia.com/tesla
 ARG TARGETARCH
 ENV TARGETARCH=$TARGETARCH
 ARG DRIVER_VERSION
+ARG GIT_COMMIT
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -95,5 +96,14 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
+
+LABEL io.k8s.display-name="NVIDIA Driver Container"
+LABEL name="NVIDIA Driver Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA driver through containers"
+LABEL description="See summary"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -14,6 +14,8 @@ ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG KERNEL_VERSION=6.8.0-44-generic
 ENV KERNEL_VERSION=$KERNEL_VERSION
 
+ARG GIT_COMMIT
+
 ENV NVIDIA_VISIBLE_DEVICES=void
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -58,5 +60,14 @@ RUN mkdir -p /usr/local/repos && \
     rm /etc/apt/sources.list.d/*
 
 WORKDIR  /drivers
+
+LABEL io.k8s.display-name="NVIDIA Driver Container"
+LABEL name="NVIDIA Driver Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_BRANCH}-${KERNEL_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA driver through containers"
+LABEL description="See summary"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/versions.mk
+++ b/versions.mk
@@ -16,3 +16,5 @@
 DRIVER_VERSIONS ?= 580.159.04 595.71.05
 
 GOLANG_VERSION := 1.26.3
+
+GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")

--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -4,6 +4,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_ARCH=x86_64
 ENV DRIVER_ARCH=$DRIVER_ARCH
+ARG GIT_COMMIT=""
 
 RUN mkdir -p /driver
 WORKDIR /driver
@@ -21,6 +22,7 @@ LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager through containers"
 LABEL description="See summary"

--- a/vgpu-manager/rhel9/Dockerfile
+++ b/vgpu-manager/rhel9/Dockerfile
@@ -17,6 +17,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_ARCH=x86_64
 ENV DRIVER_ARCH=$DRIVER_ARCH
+ARG GIT_COMMIT=""
 
 RUN mkdir -p /driver
 WORKDIR /driver
@@ -34,6 +35,7 @@ LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
 LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager through containers"
 LABEL description="See summary"

--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -4,6 +4,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_ARCH=x86_64
 ENV DRIVER_ARCH=$DRIVER_ARCH
+ARG GIT_COMMIT=""
 
 # Remove cuda repository to avoid GPG errors
 RUN rm /etc/apt/sources.list.d/cuda*.list
@@ -46,5 +47,14 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
 
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
+
+LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
+LABEL name="NVIDIA vGPU Manager Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA vGPU Manager (host driver) through containers"
+LABEL description="See summary"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/vgpu-manager/ubuntu24.04/Dockerfile
+++ b/vgpu-manager/ubuntu24.04/Dockerfile
@@ -4,6 +4,7 @@ ARG DRIVER_VERSION
 ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_ARCH=x86_64
 ENV DRIVER_ARCH=$DRIVER_ARCH
+ARG GIT_COMMIT=""
 
 # Remove cuda repository to avoid GPG errors
 RUN rm /etc/apt/sources.list.d/cuda*.list
@@ -40,5 +41,14 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
 
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
+
+LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
+LABEL name="NVIDIA vGPU Manager Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA vGPU Manager (host driver) through containers"
+LABEL description="See summary"
 
 ENTRYPOINT ["nvidia-driver", "init"]


### PR DESCRIPTION
```
$ regctl image inspect ghcr.io/nvidia/driver:eac3fe8c-570.124.06-ubuntu22.04 --format '{{ jsonPretty .Config.Labels }}'
{
  "com.nvidia.git-commit": "eac3fe8c7c066ebffb41a5592eedfc1dd36d7891",
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA Driver Container",
  "maintainer": "NVIDIA CORPORATION <cudatools@nvidia.com>",
  "name": "NVIDIA Driver Container",
  "org.opencontainers.image.ref.name": "ubuntu",
  "org.opencontainers.image.version": "22.04",
  "release": "N/A",
  "summary": "Provision the NVIDIA driver through containers",
  "vendor": "NVIDIA",
  "version": "570.124.06"
}
```