### PR TITLE
[ubuntu24.04][precompiled] update driver installation steps

### DIFF
--- a/ubuntu24.04/precompiled/nvidia-driver
+++ b/ubuntu24.04/precompiled/nvidia-driver
@@ -235,14 +235,13 @@ _unload_driver() {
 # Link and install the kernel modules from a precompiled packages
 _install_driver() {
     # Install necessary driver userspace packages
-    apt-get install -y --no-install-recommends nvidia-driver-${DRIVER_BRANCH}-server
-
-    # Uninstall unnecessary packages installed as a part of the nvidia-driver-${DRIVER_BRANCH}-server package
-    apt-get purge -y \
-        libnvidia-egl-wayland1 \
-        nvidia-dkms-${DRIVER_BRANCH}-server \
-        nvidia-kernel-source-${DRIVER_BRANCH}-server \
-        xserver-xorg-video-nvidia-${DRIVER_BRANCH}-server
+    apt-get install -y --no-install-recommends \
+        nvidia-utils-${DRIVER_BRANCH}-server \
+        nvidia-headless-no-dkms-${DRIVER_BRANCH}-server \
+        libnvidia-decode-${DRIVER_BRANCH}-server \
+        libnvidia-extra-${DRIVER_BRANCH}-server \
+        libnvidia-encode-${DRIVER_BRANCH}-server \
+        libnvidia-fbc1-${DRIVER_BRANCH}-server
 
     # Now install the precompiled kernel module packages signed by Canonical
     if [ "$OPEN_KERNEL_MODULES_ENABLED" = true ]; then


### PR DESCRIPTION
Missed these changes in the ubuntu24.04 directory when implementing the air-gapped installs of the nvidia precompiled driver packages