### PR TITLE
Add make targets for vGPU guest drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,11 @@ DISTRIBUTIONS := ubuntu18.04 ubuntu20.04 ubuntu22.04 ubuntu24.04 signed_ubuntu20
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))
 BASE_FROM := noble jammy focal
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))
+VGPU_GUEST_DRIVER_PUSH_TARGETS := $(patsubst %, push-vgpuguest-%, $(DISTRIBUTIONS))
 DRIVER_PUSH_TARGETS := $(foreach push_target, $(PUSH_TARGETS), $(addprefix $(push_target)-, $(DRIVER_VERSIONS)))
 BUILD_TARGETS := $(patsubst %, build-%, $(DISTRIBUTIONS))
 DRIVER_BUILD_TARGETS := $(foreach build_target, $(BUILD_TARGETS), $(addprefix $(build_target)-, $(DRIVER_VERSIONS)))
+VGPU_GUEST_DRIVER_BUILD_TARGETS := $(patsubst %, build-vgpuguest-%, $(DISTRIBUTIONS))
 TEST_TARGETS := $(patsubst %, test-%, $(DISTRIBUTIONS))
 PULL_TARGETS := $(patsubst %, pull-%, $(DISTRIBUTIONS))
 DRIVER_PULL_TARGETS := $(foreach pull_target, $(PULL_TARGETS), $(addprefix $(pull_target)-, $(DRIVER_VERSIONS)))
@@ -71,7 +73,7 @@ BASE_PUSH := $(patsubst %, push-base-%, $(BASE_FROM))
 BASE_BUILD_TARGETS := $(foreach target,$(BASE_BUILD),$(target))
 BASE_PUSH_TARGETS := $(foreach target,$(BASE_PUSH),$(target))
 
-PHONY: $(BASE_BUILD_TARGETS) $(BASE_PUSH_TARGETS) $(DISTRIBUTIONS) $(PUSH_TARGETS) $(BUILD_TARGETS) $(TEST_TARGETS) $(PULL_TARGETS) $(ARCHIVE_TARGETS) $(DRIVER_PUSH_TARGETS) $(DRIVER_BUILD_TARGETS) $(DRIVER_PULL_TARGETS) $(DRIVER_ARCHIVE_TARGETS)
+PHONY: $(BASE_BUILD_TARGETS) $(BASE_PUSH_TARGETS) $(DISTRIBUTIONS) $(PUSH_TARGETS) $(BUILD_TARGETS) $(TEST_TARGETS) $(PULL_TARGETS) $(ARCHIVE_TARGETS) $(DRIVER_PUSH_TARGETS) $(DRIVER_BUILD_TARGETS) $(DRIVER_PULL_TARGETS) $(DRIVER_ARCHIVE_TARGETS) $(VGPU_GUEST_DRIVER_BUILD_TARGETS) $(VGPU_GUEST_DRIVER_PUSH_TARGETS)
 
 ifeq ($(BUILD_MULTI_ARCH_IMAGES),true)
 include $(CURDIR)/multi-arch.mk
@@ -221,3 +223,44 @@ $(BASE_PUSH_TARGETS):
 	regctl \
 		image copy \
 		$(IMAGE) $(OUT_IMAGE)
+
+# $(VGPU_GUEST_DRIVER_BUILD_TARGETS) is in the form of build-vgpuguest-$(DIST)
+# The vGPU guest driver .run file is assumed to be present in the $SUBDIR/drivers/ directory.
+# VGPU_GUEST_DRIVER_VERSION must be defined in the environment when invoking this target.
+VGPU_GUEST_DRIVER_VERSION ?= ""
+build-vgpuguest-%: $(if $(VGPU_GUEST_DRIVER_VERSION),,$(error "VGPU_GUEST_DRIVER_VERSION is not set"))
+# Ensure DRIVER_VERSION has the -grid suffix
+build-vgpuguest-%: DRIVER_VERSION := $(addsuffix -grid,$(VGPU_GUEST_DRIVER_VERSION:-grid=))
+build-vgpuguest-%: DRIVER_BRANCH = $(word 1,$(subst ., ,${DRIVER_VERSION}))
+build-vgpuguest-%: DIST = $(word 3,$(subst -, ,$@))
+build-vgpuguest-%: SUBDIR = $(word 3,$(subst -, ,$@))
+build-vgpuguest-%: DOCKERFILE = $(CURDIR)/$(SUBDIR)/Dockerfile
+# Remove '-grid' substring in the image tag
+build-vgpuguest-%: DRIVER_TAG = $(DRIVER_VERSION:-grid=)
+
+build-vgpuguest-rhcos%: SUBDIR = rhel8
+
+$(VGPU_GUEST_DRIVER_BUILD_TARGETS):
+	DOCKER_BUILDKIT=1 \
+		$(DOCKER) $(BUILDX) build --pull \
+				$(DOCKER_BUILD_OPTIONS) \
+				$(DOCKER_BUILD_PLATFORM_OPTIONS) \
+				--tag $(IMAGE) \
+				--build-arg DRIVER_TYPE=vgpu \
+				--build-arg VGPU_LICENSE_SERVER_TYPE=NLS \
+				--build-arg DRIVER_VERSION="$(DRIVER_VERSION)" \
+				--build-arg DRIVER_BRANCH="$(DRIVER_BRANCH)" \
+				--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+				--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
+				$(DOCKER_BUILD_ARGS) \
+				--file $(DOCKERFILE) \
+				$(CURDIR)/$(SUBDIR)
+
+
+# $(VGPU_GUEST_DRIVER_PUSH_TARGETS) is in the form of push-vgpuguest-$(DIST)
+# VGPU_GUEST_DRIVER_VERSION must be defined in the environment when invoking this target.
+push-vgpuguest-%: $(if $(VGPU_GUEST_DRIVER_VERSION),,$(error "VGPU_GUEST_DRIVER_VERSION is not set"))
+# Remove '-grid' substring in the image tag
+push-vgpuguest-%: DRIVER_TAG = $(VGPU_GUEST_DRIVER_VERSION:-grid=)
+push-vgpuguest-%: DIST = $(word 3,$(subst -, ,$@))
+

--- a/native-only.mk
+++ b/native-only.mk
@@ -17,3 +17,7 @@ DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
 $(DRIVER_PUSH_TARGETS): push-%:
 	$(DOCKER) tag "$(IMAGE)" "$(OUT_IMAGE)"
 	$(DOCKER) push "$(OUT_IMAGE)"
+
+$(VGPU_GUEST_DRIVER_PUSH_TARGETS): push-vgpuguest-%:
+	$(DOCKER) tag "$(IMAGE)" "$(OUT_IMAGE)"
+	$(DOCKER) push "$(OUT_IMAGE)"


### PR DESCRIPTION
This PR allows one to run the following make commands to build and push vGPU guest driver images. This will simplify the instructions from https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html#build-the-driver-container (which are currently broken). 

Addresses https://github.com/NVIDIA/gpu-driver-container/issues/169