### PR TITLE
[ci] fix internal precompiled jobs

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -58,8 +58,8 @@ workflow:
 .precompiled-rules:
   # only execute precompiled jobs on scheduled pipelines
   rules:
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: never
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: always
 
 trigger-pipeline:
   stage: trigger

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -94,8 +94,8 @@ image-precompiled-ubuntu24.04:
     PRECOMPILED: "true"
     CVE_UPDATES: "curl libc6"
   rules:
-    - !reference [.precompiled-rules, rules]
-    - when: delayed
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: delayed
       start_in: 30 minutes
   extends:
     - .driver-versions-precompiled-ubuntu24.04
@@ -119,8 +119,8 @@ image-precompiled-ubuntu22.04:
     PRECOMPILED: "true"
     CVE_UPDATES: "curl libc6"
   rules:
-    - !reference [.precompiled-rules, rules]
-    - when: delayed
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: delayed
       start_in: 30 minutes
   extends:
     - .driver-versions-precompiled-ubuntu22.04
@@ -238,7 +238,6 @@ image-rhel8:
   rules:
     - !reference [.scan-rules-common, rules]
     - !reference [.precompiled-rules, rules]
-    - when: always
 
 .scan-precompiled-ubuntu22.04:
   variables:
@@ -251,7 +250,6 @@ image-rhel8:
   rules:
     - !reference [.scan-rules-common, rules]
     - !reference [.precompiled-rules, rules]
-    - when: always
 
 # Define the scan targets
 scan-ubuntu20.04-amd64:
@@ -533,8 +531,7 @@ sign:ngc-precompiled-ubuntu22.04:
   needs:
     - release:ngc-precompiled-ubuntu22.04
   rules:
-    # Only run NGC release job on scheduled pipelines
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - !reference [.precompiled-rules, rules]
 
 sign:ngc-ubuntu-rhel-rhcos:
   extends:


### PR DESCRIPTION
If 'rules' are defined for a Gitlab CI job, then the job will only be added to the pipeline if one of the rules matches. This commit ensures that for scheduled pipelines, at least one rule matches for the precompiled jobs which are meant to run on the schedule.