### PR TITLE
Revert "Reintroduce OPEN_KERNEL_MODULES_ENABLED envvar for backwards compatibility"

### DIFF
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -17,9 +17,7 @@ USE_HOST_MOFED="${USE_HOST_MOFED:-false}"
 DNF_RELEASEVER=${DNF_RELEASEVER:-""}
 RHEL_VERSION=${RHEL_VERSION:-""}
 RHEL_MAJOR_VERSION=8
-
-OPEN_KERNEL_MODULES_ENABLED=${OPEN_KERNEL_MODULES_ENABLED:-}
-KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-}
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-auto}
 
 DRIVER_ARCH=${TARGETARCH/amd64/x86_64} && DRIVER_ARCH=${DRIVER_ARCH/arm64/aarch64}
 echo "DRIVER_ARCH is $DRIVER_ARCH"
@@ -600,13 +598,6 @@ _shutdown() {
 # to install. Valid values for KERNEL_MODULE_TYPE are 'auto' (default), 'open', and 'proprietary'.
 # When 'auto' is configured, we use the nvidia-installer to recommend the module type to install.
 _resolve_kernel_type() {
-  # For backwards compatibility with older GPU Operator versions where KERNEL_MODULE_TYPE is not set,
-  # honor the deprecated OPEN_KERNEL_MODULES_ENABLED field
-  if [ -z "${KERNEL_MODULE_TYPE}" ]; then
-    [[ "${OPEN_KERNEL_MODULES_ENABLED}" == "true" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
-    return 0
-  fi
-
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
     KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -17,9 +17,7 @@ USE_HOST_MOFED="${USE_HOST_MOFED:-false}"
 DNF_RELEASEVER=${DNF_RELEASEVER:-""}
 RHEL_VERSION=${RHEL_VERSION:-""}
 RHEL_MAJOR_VERSION=9
-
-OPEN_KERNEL_MODULES_ENABLED=${OPEN_KERNEL_MODULES_ENABLED:-}
-KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-}
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-auto}
 
 DRIVER_ARCH=${TARGETARCH/amd64/x86_64} && DRIVER_ARCH=${DRIVER_ARCH/arm64/aarch64}
 echo "DRIVER_ARCH is $DRIVER_ARCH"
@@ -600,13 +598,6 @@ _shutdown() {
 # to install. Valid values for KERNEL_MODULE_TYPE are 'auto' (default), 'open', and 'proprietary'.
 # When 'auto' is configured, we use the nvidia-installer to recommend the module type to install.
 _resolve_kernel_type() {
-  # For backwards compatibility with older GPU Operator versions where KERNEL_MODULE_TYPE is not set,
-  # honor the deprecated OPEN_KERNEL_MODULES_ENABLED field
-  if [ -z "${KERNEL_MODULE_TYPE}" ]; then
-    [[ "${OPEN_KERNEL_MODULES_ENABLED}" == "true" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
-    return 0
-  fi
-
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
     KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then

--- a/ubuntu20.04/nvidia-driver
+++ b/ubuntu20.04/nvidia-driver
@@ -15,9 +15,7 @@ NVIDIA_UVM_MODULE_PARAMS=()
 NVIDIA_MODESET_MODULE_PARAMS=()
 NVIDIA_PEERMEM_MODULE_PARAMS=()
 TARGETARCH=${TARGETARCH:?"Missing TARGETARCH env"}
-
-OPEN_KERNEL_MODULES_ENABLED=${OPEN_KERNEL_MODULES_ENABLED:-}
-KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-}
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-auto}
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -485,13 +483,6 @@ _shutdown() {
 # to install. Valid values for KERNEL_MODULE_TYPE are 'auto' (default), 'open', and 'proprietary'.
 # When 'auto' is configured, we use the nvidia-installer to recommend the module type to install.
 _resolve_kernel_type() {
-  # For backwards compatibility with older GPU Operator versions where KERNEL_MODULE_TYPE is not set,
-  # honor the deprecated OPEN_KERNEL_MODULES_ENABLED field
-  if [ -z "${KERNEL_MODULE_TYPE}" ]; then
-    [[ "${OPEN_KERNEL_MODULES_ENABLED}" == "true" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
-    return 0
-  fi
-
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
     KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -15,9 +15,7 @@ NVIDIA_UVM_MODULE_PARAMS=()
 NVIDIA_MODESET_MODULE_PARAMS=()
 NVIDIA_PEERMEM_MODULE_PARAMS=()
 TARGETARCH=${TARGETARCH:?"Missing TARGETARCH env"}
-
-OPEN_KERNEL_MODULES_ENABLED=${OPEN_KERNEL_MODULES_ENABLED:-}
-KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-}
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-auto}
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -540,13 +538,6 @@ _shutdown() {
 # to install. Valid values for KERNEL_MODULE_TYPE are 'auto' (default), 'open', and 'proprietary'.
 # When 'auto' is configured, we use the nvidia-installer to recommend the module type to install.
 _resolve_kernel_type() {
-  # For backwards compatibility with older GPU Operator versions where KERNEL_MODULE_TYPE is not set,
-  # honor the deprecated OPEN_KERNEL_MODULES_ENABLED field
-  if [ -z "${KERNEL_MODULE_TYPE}" ]; then
-    [[ "${OPEN_KERNEL_MODULES_ENABLED}" == "true" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
-    return 0
-  fi
-
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
     KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then


### PR DESCRIPTION
This reverts commit efd73d849fb88bacd5ed8438f53bcb85c7acab82.

With the next gpu-operator release on the horizon, we no longer need to maintain this backcompat logic. All future driver containers will utilise the KERNEL_MODULE_TYPE env var going forward