### PR TITLE
[vgpu-manager/ubuntu22.04] Install gcc-12 in vgpu driver manager container

### DIFF
--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -18,6 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pciutils && \
     rm -rf /var/lib/apt/lists/*
 
+# Install the gcc-12 package in Ubuntu 22.04 as Kernels with versions 5.19.x and 6.5.x need gcc 12.3.0 for compilation
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc-12 g++-12 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main universe" > /etc/apt/sources.list && \
     echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main universe" >> /etc/apt/sources.list && \
     echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main universe" >> /etc/apt/sources.list && \


### PR DESCRIPTION
This was fixed in dd69782dc6a21aa92ded68fb9db58bd4b1a23a4a (cc @tariq1890) for regular installs, but vgpu-manager still fails to compile drivers in Ubuntu22.04 with Kernels in 5.19.x/6.5.x

This fix seemed appropriate and straight-forward enough to simply port it to the vgpu-manager image