### PR TITLE
Release ubuntu22.04 6.8 kernel driver

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -95,7 +95,7 @@ trigger-pipeline:
     matrix:
       - DRIVER_BRANCH: [535, 550, 570]
         KERNEL_FLAVOR: [aws, azure, generic, nvidia, oracle]
-        LTS_KERNEL: ["5.15"]
+        LTS_KERNEL: ["5.15", "6.8"]
 
 # Define the matrix of precompiled jobs that can be run in parallel for ubuntu24.04
 .driver-versions-precompiled-ubuntu24.04:


### PR DESCRIPTION
Once QA tests the Ubuntu 22.04 6.8 kernel, 
we will merge this change into the main branch to release the driver container for Ubuntu 22.04 6.8.