### PR TITLE
print the nvidia-persisentenced stop message only if pid is detected

### DIFF
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -425,8 +425,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -425,8 +425,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/ubuntu20.04/nvidia-driver
+++ b/ubuntu20.04/nvidia-driver
@@ -336,8 +336,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/ubuntu20.04/precompiled/nvidia-driver
+++ b/ubuntu20.04/precompiled/nvidia-driver
@@ -145,8 +145,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -372,8 +372,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/ubuntu22.04/precompiled/nvidia-driver
+++ b/ubuntu22.04/precompiled/nvidia-driver
@@ -209,8 +209,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -303,8 +303,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/ubuntu24.04/precompiled/nvidia-driver
+++ b/ubuntu24.04/precompiled/nvidia-driver
@@ -209,8 +209,8 @@ _unload_driver() {
     local nvidia_modeset_refs=0
     local nvidia_peermem_refs=0
 
-    echo "Stopping NVIDIA persistence daemon..."
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
         kill -SIGTERM "${pid}"

--- a/vgpu-manager/rhel8/nvidia-driver
+++ b/vgpu-manager/rhel8/nvidia-driver
@@ -112,8 +112,8 @@ _unload_driver() {
     local nvidia_refs=0
     local nvidia_vgpu_vfio_refs=0
 
-    echo "Stopping NVIDIA vGPU Manager..."
     if [ -f /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid ]; then
+        echo "Stopping NVIDIA vGPU Manager..."
         local pid=$(< /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid)
 
         kill -TERM "${pid}"

--- a/vgpu-manager/ubuntu20.04/nvidia-driver
+++ b/vgpu-manager/ubuntu20.04/nvidia-driver
@@ -186,8 +186,8 @@ _unload_driver() {
     local nvidia_refs=0
     local nvidia_vgpu_vfio_refs=0
 
-    echo "Stopping NVIDIA vGPU Manager..."
     if [ -f /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid ]; then
+        echo "Stopping NVIDIA vGPU Manager..."
         local pid=$(< /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid)
 
         kill -TERM "${pid}"

--- a/vgpu-manager/ubuntu22.04/nvidia-driver
+++ b/vgpu-manager/ubuntu22.04/nvidia-driver
@@ -186,8 +186,8 @@ _unload_driver() {
     local nvidia_refs=0
     local nvidia_vgpu_vfio_refs=0
 
-    echo "Stopping NVIDIA vGPU Manager..."
     if [ -f /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid ]; then
+        echo "Stopping NVIDIA vGPU Manager..."
         local pid=$(< /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid)
 
         kill -TERM "${pid}"


### PR DESCRIPTION
This is consistent with the rest of the daemons (gridd, fabric manager, nvlsm) managed by the driver container