### PR TITLE
 check pod ready status timeout fix

### DIFF
--- a/tests/scripts/.definitions.sh
+++ b/tests/scripts/.definitions.sh
@@ -16,7 +16,7 @@ CASES_DIR="$( cd "${TEST_DIR}/cases" && pwd )"
 
 : ${HELM_NVIDIA_REPO:="https://helm.ngc.nvidia.com/nvidia"}
 
-: ${DAEMON_POD_STATUS_TIME_OUT:="15m"}
+: ${DAEMON_POD_STATUS_TIME_OUT:="30m"}
 : ${POD_STATUS_TIME_OUT:="2m"}
 
 : ${LOG_DIR:="/tmp/logs"}


### PR DESCRIPTION
increase daemon pod status check time out .
Current DAEMON_POD_STATUS_TIME_OUT = 15 minutes, with current kernel release it is getting timed out and e2e is failing.

pipeline: https://github.com/NVIDIA/gpu-driver-container/actions/runs/15182510763/job/42758344006#step:13:484