### PR TITLE
Remove unused jq package in rhel8 and rhel9 images

### DIFF
--- a/rhel8/install.sh
+++ b/rhel8/install.sh
@@ -14,8 +14,7 @@ dep_installer () {
         glibc.i686 \
         make \
         cpio \
-        kmod \
-        jq
+        kmod
   elif [ "$DRIVER_ARCH" = "ppc64le" ]; then
     dnf install -y \
         libglvnd-glx \
@@ -25,8 +24,7 @@ dep_installer () {
         glibc \
         make \
         cpio \
-        kmod \
-        jq
+        kmod
   elif [ "$DRIVER_ARCH" = "aarch64" ]; then
     dnf install -y \
         libglvnd-glx \
@@ -36,8 +34,7 @@ dep_installer () {
         glibc \
         make \
         cpio \
-        kmod \
-        jq
+        kmod
   fi
   rm -rf /var/cache/yum/*
 }

--- a/rhel9/install.sh
+++ b/rhel9/install.sh
@@ -16,8 +16,7 @@ dep_installer () {
         glibc.i686 \
         make \
         cpio \
-        kmod \
-        jq
+        kmod
   elif [ "$DRIVER_ARCH" = "ppc64le" ]; then
     dnf install -y \
         libglvnd-glx \
@@ -27,8 +26,7 @@ dep_installer () {
         glibc \
         make \
         cpio \
-        kmod \
-        jq
+        kmod
   elif [ "$DRIVER_ARCH" = "aarch64" ]; then
     dnf install -y \
         libglvnd-glx \
@@ -38,8 +36,7 @@ dep_installer () {
         glibc \
         make \
         cpio \
-        kmod \
-        jq
+        kmod
   fi
   rm -rf /var/cache/yum/*
 }


### PR DESCRIPTION
The jq package was added in https://github.com/NVIDIA/gpu-driver-container/commit/926a283047e0b03da8a5384ac307aa64e046e41a. The code that invoked jq was subsequently removed in https://github.com/NVIDIA/gpu-driver-container/commit/c9a6afcd4b473a1978c8eeb0f9292d375a0e2154.