### PR TITLE
add support for RHEL9.6

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -479,12 +479,12 @@ release:ngc-rhel9.4:
   variables:
     OUT_DIST: "rhel9.4"
 
-release:ngc-rhel9.5:
+release:ngc-rhel9.6:
   extends:
     - .release:ngc
     - .dist-rhel9
   variables:
-    OUT_DIST: "rhel9.5"
+    OUT_DIST: "rhel9.6"
 
 # Define the external image signing steps for NGC
 # Download the ngc cli binary for use in the sign steps
@@ -592,7 +592,7 @@ sign:ngc-ubuntu-rhel-rhcos:
       VERSION: ["20.04"]
       DRIVER_VERSION: ["535.247.01", "550.163.01", "570.148.08"]
     - SIGN_JOB_NAME: ["rhel"]
-      VERSION: ["8.8", "8.10", "9.4", "9.5"]
+      VERSION: ["8.8", "8.10", "9.4", "9.6"]
       DRIVER_VERSION: ["535.247.01", "550.163.01", "570.148.08"]
     - SIGN_JOB_NAME: ["rhcos"]
       VERSION: ["4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18"]


### PR DESCRIPTION
With the release of an even-numbered minor release, the preceding odd-numbered minor gets EOL'ed, so we place RHEL 9.5 with RHEL 9.6

source: https://access.redhat.com/support/policy/updates/errata