### PR TITLE
Addition of 64k kernel-flavor in KERNEL_VERSION

### DIFF
--- a/ubuntu16.04/nvidia-driver
+++ b/ubuntu16.04/nvidia-driver
@@ -28,14 +28,16 @@ _cleanup_package_cache() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }

--- a/ubuntu18.04/nvidia-driver
+++ b/ubuntu18.04/nvidia-driver
@@ -31,14 +31,16 @@ _cleanup_package_cache() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }

--- a/ubuntu20.04/nvidia-driver
+++ b/ubuntu20.04/nvidia-driver
@@ -47,7 +47,8 @@ _update_ca_certificates() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
@@ -55,7 +56,7 @@ _resolve_kernel_version() {
         return 1
     fi
 
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -47,7 +47,8 @@ _update_ca_certificates() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
@@ -55,7 +56,7 @@ _resolve_kernel_version() {
         return 1
     fi
 
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -47,7 +47,8 @@ _update_ca_certificates() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
@@ -55,7 +56,7 @@ _resolve_kernel_version() {
         return 1
     fi
 
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }

--- a/vgpu-manager/ubuntu20.04/nvidia-driver
+++ b/vgpu-manager/ubuntu20.04/nvidia-driver
@@ -29,7 +29,8 @@ _cleanup_package_cache() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
@@ -37,7 +38,7 @@ _resolve_kernel_version() {
         return 1
     fi
 
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }

--- a/vgpu-manager/ubuntu22.04/nvidia-driver
+++ b/vgpu-manager/ubuntu22.04/nvidia-driver
@@ -29,7 +29,8 @@ _cleanup_package_cache() {
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
       sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
+    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     echo "Resolving Linux kernel version..."
     if [ -z "${version}" ]; then
@@ -37,7 +38,7 @@ _resolve_kernel_version() {
         return 1
     fi
 
-    KERNEL_VERSION="${version}-${flavor:-generic}"
+    KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
     return 0
 }


### PR DESCRIPTION
The driver container fails to install on kernels of the generic-64k flavor. The root cause is that the [resolve_kernel_version() function](https://github.com/NVIDIA/gpu-driver-container/blob/e9db94520c008aec0bc6279bfbade65600c8135f/ubuntu22.04/nvidia-driver#L47-L61) is stripping the "-64k" suffix from the kernel version string. So when we attempt to install the kernel-header packages, we are installing the wrong version of the packages.


script tested on arm64 target : 

```
./run.sh 6.8.0-51-generic-64k

run.sh 

#!/bin/bash
get_kernel() {
        local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
	sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
	local flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//' | grep -Ev "^generic|virtual")
	local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
	kernel_flavor="${kernel_flavor//virtual/generic}"

	echo "Resolving Linux kernel version..."
	if [ -z "${version}" ]; then
		echo "Could not resolve Linux kernel version" >&2
		return 1
	fi

	KERNEL_VERSION="${version}-${flavor:-$kernel_flavor}"
	echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
}

export KERNEL_VERSION=$1
get_kernel
```

output : 
_Resolving Linux kernel version...
Proceeding with Linux kernel version 6.8.0-51-generic-64k_
