### PR TITLE
[rhel9] add support for ARM-based OS versions

### DIFF
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -142,7 +142,17 @@ _install_prerequisites() (
 
     echo "Generating Linux kernel version string..."
     if [ "$TARGETARCH" = "arm64" ]; then
-        gunzip -c /lib/modules/${KERNEL_VERSION}/vmlinuz | strings | grep -E '^Linux version' | sed 's/^\(.*\)\s\+(.*)$/\1/' > version
+        # Download unzboot as Kernel Images are compressed in the zboot on RHEL9 ARM
+        # unzboot is only available on the EPEL RPM repo
+        dnf -q -y --releasever=${DNF_RELEASEVER} install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+        dnf config-manager --enable epel
+        dnf -q -y --releasever=${DNF_RELEASEVER} install unzboot
+
+        if ! unzboot /lib/modules/${KERNEL_VERSION}/vmlinuz vmlinuz.out; then
+          echo "Could not extract /lib/modules/${KERNEL_VERSION}/vmlinuz"
+        fi
+
+        < vmlinuz.out strings | grep -E '^Linux version' | sed 's/^\(.*\)\s\+(.*)$/\1/' > version
     else
         extract-vmlinux /lib/modules/${KERNEL_VERSION}/vmlinuz | strings | grep -E '^Linux version' | sed 's/^\(.*\)\s\+(.*)$/\1/' > version
     fi


### PR DESCRIPTION
This PR fixes a bug in the driver container when running on ARM-based machines with Red Hat Enterprise Linux 9