### PR TITLE
install elfutils packages after dnf_releasever is resolved

### DIFF
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -92,12 +92,6 @@ _install_prerequisites() (
     trap "rm -rf ${tmp_dir}" EXIT
     cd ${tmp_dir}
 
-    echo "Installing elfutils..."
-    if ! dnf install -q -y elfutils-libelf.$DRIVER_ARCH elfutils-libelf-devel.$DRIVER_ARCH; then
-        echo "FATAL: failed to install elfutils packages. RHEL entitlement may be improperly deployed."
-        exit 1
-    fi
-
     rm -rf /lib/modules/${KERNEL_VERSION}
     mkdir -p /lib/modules/${KERNEL_VERSION}/proc
 
@@ -123,6 +117,13 @@ _install_prerequisites() (
       else
         DNF_RELEASEVER=${RHEL_MAJOR_VERSION}
       fi
+    fi
+
+    echo "Installing elfutils..."
+    dnf install -q -y --releasever=${DNF_RELEASEVER} elfutils-libelf.$DRIVER_ARCH
+    if ! dnf install -y --releasever=${DNF_RELEASEVER} elfutils-libelf-devel.$DRIVER_ARCH; then
+        echo "FATAL: failed to install elfutils-libel-devel. RHEL entitlement may be improperly deployed."
+        exit 1
     fi
 
     echo "Installing Linux kernel headers..."

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -94,12 +94,6 @@ _install_prerequisites() (
     trap "rm -rf ${tmp_dir}" EXIT
     cd ${tmp_dir}
 
-    echo "Installing elfutils..."
-    if ! dnf install -q -y elfutils-libelf.$DRIVER_ARCH elfutils-libelf-devel.$DRIVER_ARCH; then
-        echo "FATAL: failed to install elfutils packages. RHEL entitlement may be improperly deployed."
-        exit 1
-    fi
-
     rm -rf /lib/modules/${KERNEL_VERSION}
     mkdir -p /lib/modules/${KERNEL_VERSION}/proc
 
@@ -125,6 +119,13 @@ _install_prerequisites() (
       else
         DNF_RELEASEVER=${RHEL_MAJOR_VERSION}
       fi
+    fi
+
+    echo "Installing elfutils..."
+    dnf install -q -y --releasever=${DNF_RELEASEVER} elfutils-libelf.$DRIVER_ARCH
+    if ! dnf install -y --releasever=${DNF_RELEASEVER} elfutils-libelf-devel.$DRIVER_ARCH; then
+        echo "FATAL: failed to install elfutils-libel-devel. RHEL entitlement may be improperly deployed."
+        exit 1
     fi
 
     echo "Installing Linux kernel headers..."


### PR DESCRIPTION
Summary of changes

i) Install `libelf-elfutils` and `libelf-elfutils-devel` packages after the DNF release version is resolved. This was done to support clusters using a custom RHEL RPM package repo

ii) Install `libelf-elfutils` and `libelf-elfutils-devel` packages in separate steps. This is done as the devel packages depend on the former in more recent RHEL versions. Installing the devel package may require downgrading the `libelf-elfutils` package, and serialised installation of the two packages will allow for automatic downgrading and unblock the installation of the devel package
