### PR TITLE
Include lspci in vgpu-manager image

### DIFF
--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -5,7 +5,11 @@ ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_ARCH=x86_64
 ENV DRIVER_ARCH=$DRIVER_ARCH
 
-RUN mkdir -p /driver
+RUN mkdir -p /driver/rpms/pciutils
+WORKDIR /driver/rpms/pciutils
+
+RUN dnf download --resolve pciutils && dnf clean all
+
 WORKDIR /driver
 COPY NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run .
 RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run

--- a/vgpu-manager/rhel8/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel8/ocp_dtk_entrypoint
@@ -100,7 +100,7 @@ dtk-build-driver() {
 
     # ensure lspci is installed, as 'sriov-manage' script requires it
     if ! $(lspci >/dev/null); then
-      dnf install -y pciutils && rm -rf /var/cache/yum/*
+      rpm -ivh ${DRIVER_TOOLKIT_SHARED_DIR}/driver/rpms/pciutils/*.rpm
     fi
 
     # upon catching a signal, terminate child process to trigger driver cleanup


### PR DESCRIPTION
In disconnected environments `dnf install` cannot be used without mirroring RPM repositories. As the vGPU manager now requires lspci command:

* Include the RPMs in the container image
* If lspci command not found, install it from the RPMs