### PR TITLE
[ubuntu24.04][FIPS] disable FIPS enforcement temporarily when enabling pro mode

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -28,10 +28,20 @@ _enable_fips_if_required() {
     if [[ -n "${UBUNTU_PRO_TOKEN}" && ${KERNEL_VERSION} =~ "fips" ]]; then
       echo "Ubuntu Pro token and FIPS kernel detected"
       apt-get -qq install --no-install-recommends ubuntu-advantage-tools > /dev/null
+
+      # This workaround is needed in Ubuntu 24.04 as OpenSSL attempts to leverage the FIPS provider
+      # when the underlying kernel is FIPS enabled.
+      export OPENSSL_FORCE_FIPS_MODE=0
+
       echo "Attaching Ubuntu Pro token..."
       pro attach --no-auto-enable "${UBUNTU_PRO_TOKEN}"
       echo "Enabling FIPS apt repo access..."
       pro enable --access-only --assume-yes fips-updates
+      echo "Installing the OpenSSL FIPS modules"
+      apt-get -qq install --no-install-recommends ubuntu-fips-userspace > /dev/null
+
+      # With the OpenSSL FIPS module installed, OpenSSL can now work with the default settings,
+      unset OPENSSL_FORCE_FIPS_MODE
     fi
 }
 


### PR DESCRIPTION
When running `pro attach` on an Ubuntu 24.04 container, we are faced with a strange "chicken & egg" problem as the pro client attempts to use openssl + fips when it detects that the underlying kernel is fips_enabled, however, the FIPS packages are only available after the pro client enables APT repo access to the FIPS packages.

To work around this problem, we explicitly set the env var `OPENSSL_FORCE_FIPS_MODE=0` to unblock the pro client calls. After successful enablement of FIPS mode, we download the OpenSSL FIPS module and unset the `OPENSSL_FORCE_FIPS_MODE` env var