### PR TITLE
Precompiled: disabled the ubuntu22.04 6.8 kernel

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -134,6 +134,9 @@ jobs:
             dist: ubuntu24.04
           - lts_kernel: 5.15
             dist: ubuntu24.04
+          # FIXME -- remove once we need to release 6.8 kernel for ubuntu22.04
+          - lts_kernel: 6.8
+            dist: ubuntu22.04
     steps:
       - uses: actions/checkout@v4
         name: Check out code

--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -67,6 +67,9 @@ jobs:
             driver_branch: 535
           - lts_kernel: 5.15
             dist: ubuntu24.04
+          # FIXME -- remove once we need to release 6.8 kernel for ubuntu22.04
+          - lts_kernel: 6.8
+            dist: ubuntu22.04
     steps:
       - uses: actions/checkout@v4
         name: Check out code


### PR DESCRIPTION
disabled the ubuntu22.04 6.8 kernel as it was unnecessarily consuming AWS resource for e2e testing. we will enable it once we decide to release