### PR TITLE
Restrict e2e runs to 5 instances

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -296,6 +296,7 @@ jobs:
       matrix:
         kernel_version: ${{ fromJson(needs.collect-e2e-test-matrix.outputs.matrix_values) }}
         exclude: ${{ fromJson(needs.collect-e2e-test-matrix.outputs.exclude_matrix_values) }}
+      max-parallel: 5
     steps:
       - name: Check out code
         uses: actions/checkout@v5


### PR DESCRIPTION
Sometimes ,new kernel releases or enabling full fledged e2e AWS testing , creates too many instances ( >= 12) . This change will restrict AWS instances to batches of 5 . Once a batch of 5 completes , another batch of upto 5 instances will be created to continue running the e2e tests . 
This will resolve  AWS account instance limit error ( vpcs creation)