### PR TITLE
bump ubuntu24.04 base image to noble-20250910

### DIFF
--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:noble-20250716
+ARG BASE_IMAGE=ubuntu:noble-20250910
 
 FROM ${BASE_IMAGE} as build
 


### PR DESCRIPTION
TODO: figure out a way to automate updates of the ubuntu 24.04 base image when referenced via a build arg. `dependabot` does not seem to support this, so we many need to consider using `renovate` instead