### PR TITLE
Regex fix for custom kernel naming

### DIFF
--- a/ubuntu16.04/nvidia-driver
+++ b/ubuntu16.04/nvidia-driver
@@ -27,7 +27,7 @@ _cleanup_package_cache() {
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
+     sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.](([0-9]+)(-[a-zA-Z0-9]+)?).*/\1-\3/p'| head -1)
     local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
     kernel_flavor="${kernel_flavor//virtual/generic}"
 

--- a/ubuntu18.04/nvidia-driver
+++ b/ubuntu18.04/nvidia-driver
@@ -30,7 +30,7 @@ _cleanup_package_cache() {
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.](([0-9]+)(-[a-zA-Z0-9]+)?).*/\1-\3/p'| head -1)
     local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
     kernel_flavor="${kernel_flavor//virtual/generic}"
 

--- a/ubuntu20.04/nvidia-driver
+++ b/ubuntu20.04/nvidia-driver
@@ -46,7 +46,7 @@ _update_ca_certificates() {
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.](([0-9]+)(-[a-zA-Z0-9]+)?).*/\1-\3/p'| head -1)
     local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
     kernel_flavor="${kernel_flavor//virtual/generic}"
 

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -58,7 +58,7 @@ _update_ca_certificates() {
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.](([0-9]+)(-[a-zA-Z0-9]+)?).*/\1-\3/p'| head -1)
     local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
     kernel_flavor="${kernel_flavor//virtual/generic}"
 

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -68,7 +68,7 @@ _update_ca_certificates() {
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
     local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.](([0-9]+)(-[a-zA-Z0-9]+)?).*/\1-\3/p'| head -1)
     local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
     kernel_flavor="${kernel_flavor//virtual/generic}"
 


### PR DESCRIPTION
Current regex implementation in the `_resolve_kernel_version()` fails to work with custom kernels like `6.11.0-01075-gc758b3587a28` 

This PR Fixes the hard requirement for numeric component for the build number in the Custom Linux Kernel naming convention.
Ubuntu GPU driver containers only. 

```
root@ubuntu:~# k logs -n nvidia-gpu-operator nvidia-driver-daemonset-kr8vj -c nvidia-driver-ctr -f
DRIVER_ARCH is aarch64

========== NVIDIA Software Installer ==========

Starting installation of NVIDIA driver version 575.57.08 for Linux kernel version 6.11.0-01075-gc758b3587a28

Unloading NVIDIA driver kernel modules...
Unmounting NVIDIA driver rootfs...
Updating the package cache...
Resolving Linux kernel version...
Unloading NVIDIA driver kernel modules...
Could not resolve Linux kernel version
Unmounting NVIDIA driver rootfs…
```