### PR TITLE
ensure that the base image from the build arg is used in the final stage

### DIFF
--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -28,7 +28,7 @@ RUN if [ "$DRIVER_TYPE" = "vgpu" ]; then \
     go build -o vgpu-util && \
     mv vgpu-util /work; fi
 
-FROM nvcr.io/nvidia/cuda:13.0.1-base-ubi9
+FROM ${BASE_IMAGE}
 
 ARG TARGETARCH
 ENV TARGETARCH=$TARGETARCH


### PR DESCRIPTION
We were only using the specified custom base image in the first stage of the image build. This PR ensures that we use the custom base image in all of the build stages (this Dockerfile has 2 build stages)