### PR TITLE
Add rhel9 base for vGPU-manager containers

### DIFF
--- a/vgpu-manager/rhel9/Dockerfile
+++ b/vgpu-manager/rhel9/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM nvcr.io/nvidia/cuda:13.0.2-base-ubi9
+
+ARG DRIVER_VERSION
+ENV DRIVER_VERSION=$DRIVER_VERSION
+ARG DRIVER_ARCH=x86_64
+ENV DRIVER_ARCH=$DRIVER_ARCH
+
+RUN mkdir -p /driver
+WORKDIR /driver
+COPY NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run .
+RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
+
+COPY nvidia-driver /usr/local/bin
+COPY ocp_dtk_entrypoint /usr/local/bin
+
+LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
+LABEL name="NVIDIA vGPU Manager Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_VERSION}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA vGPU Manager through containers"
+LABEL description="See summary"
+
+# Install / upgrade packages here that are required to resolve CVEs
+ARG CVE_UPDATES
+RUN if [ -n "${CVE_UPDATES}" ]; then \
+        yum update -y ${CVE_UPDATES} && \
+        rm -rf /var/cache/yum/*; \
+    fi
+
+# Add NGC DL license from the CUDA image
+RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
+
+ENTRYPOINT ["nvidia-driver", "init"]

--- a/vgpu-manager/rhel9/nvidia-driver
+++ b/vgpu-manager/rhel9/nvidia-driver
@@ -1,0 +1,264 @@
+#!/bin/bash
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+DRIVER_VERSION=${DRIVER_VERSION:?"Missing driver version"}
+DRIVER_RESET_RETRIES=10
+DELAY_BEFORE_VF_CREATION=${DELAY_BEFORE_VF_CREATION:-15}
+RUN_DIR=/run/nvidia
+
+# Mount the driver rootfs into the run directory with the exception of sysfs.
+_mount_rootfs() {
+    echo "Mounting NVIDIA driver rootfs..."
+    mount --make-runbindable /sys
+    mount --make-private /sys
+    mkdir -p ${RUN_DIR}/driver
+    mount --rbind / ${RUN_DIR}/driver
+
+    echo "Change device files security context for selinux compatibility"
+    chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+}
+
+# Unmount the driver rootfs from the run directory.
+_unmount_rootfs() {
+    echo "Unmounting NVIDIA driver rootfs..."
+    if findmnt -r -o TARGET | grep "${RUN_DIR}/driver" > /dev/null; then
+        umount -l -R ${RUN_DIR}/driver
+    fi
+}
+
+# Create /dev/char directory if it doesn't exist inside the container.
+# Without this directory, nvidia-vgpu-mgr will fail to create symlinks
+# under /dev/char for new devices nodes.
+_create_dev_char_directory() {
+	if [ ! -d "/dev/char" ]; then
+		echo "Creating '/dev/char' directory"
+		mkdir -p /dev/char
+	fi
+}
+
+_set_fw_search_path() {
+    local nv_fw_search_path="$RUN_DIR/driver/lib/firmware"
+    local fw_path_config_file="/sys/module/firmware_class/parameters/path"
+
+    if [[ ! -z $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
+        echo "WARNING: A search path is already configured in $fw_path_config_file"
+        echo "         Retaining the current configuration. Note, GSP firmware may not be found and thus won't be used by the NVIDIA driver."
+        return
+    fi
+
+    echo "Configuring the following firmware search path in '$fw_path_config_file': $nv_fw_search_path"
+    echo -n "$nv_fw_search_path" > $fw_path_config_file
+}
+
+_install_driver() {
+    local tmp_dir=$(mktemp -d)
+
+    sh NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run --ui=none --no-questions --tmpdir ${tmp_dir} --no-systemd
+}
+
+# Currently _install_driver() takes care of loading nvidia modules. Just need to start necessary vgpu daemons
+_load_driver() {
+    /usr/bin/nvidia-vgpud
+    /usr/bin/nvidia-vgpu-mgr &
+
+    # check nvidia drivers are loaded
+    if [ ! -f /sys/module/nvidia_vgpu_vfio/refcnt ] || [ ! -f /sys/module/nvidia/refcnt ]; then
+        echo "Failed to load nvidia driver"
+        return 1
+    fi
+    return 0
+}
+
+# Enable virtual functions for all physical GPUs on the node that support SR-IOV.
+# Retry logic is to account for when the driver is busy (i.e. during driver initialization)
+_enable_vfs() {
+    # Wait before attempting to create VFs to ensure the driver has finished initializing.
+    # This is a WAR for a bug in vGPU 17.2 where sriov-manage does not return a non-zero
+    # exit code even though VF creation fails.
+    sleep $DELAY_BEFORE_VF_CREATION
+
+    local retry
+    for ((retry = 0 ; retry <= $DRIVER_RESET_RETRIES ; retry++)); do
+        if /usr/lib/nvidia/sriov-manage -e ALL; then
+            return 0
+        fi
+        if [ $retry == $DRIVER_RESET_RETRIES ]; then
+            echo "Failed to enable VFs"
+        fi
+    done
+    return 1
+}
+
+# Disable virtual functions for all physical GPUs on the node that support SR-IOV.
+# Retry logic is to account for when the driver is busy (i.e. during driver initialization)
+_disable_vfs() {
+    local retry
+    for ((retry = 0 ; retry <= $DRIVER_RESET_RETRIES ; retry++)); do
+        if /usr/lib/nvidia/sriov-manage -d ALL; then
+            return 0
+        fi
+        if [ $retry == $DRIVER_RESET_RETRIES ]; then
+            echo "Failed to disable VFs"
+        fi
+    done
+    return 1
+}
+
+_unload_driver() {
+    local rmmod_args=()
+    local nvidia_deps=0
+    local nvidia_refs=0
+    local nvidia_vgpu_vfio_refs=0
+
+    if [ -f /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid ]; then
+        echo "Stopping NVIDIA vGPU Manager..."
+        local pid=$(< /var/run/nvidia-vgpu-mgr/nvidia-vgpu-mgr.pid)
+
+        kill -TERM "${pid}"
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ $i -eq 50 ]; then
+            echo "Could not stop NVIDIA vGPU Manager" >&2
+            return 1
+        fi
+    fi
+
+    echo "Unloading NVIDIA driver kernel modules..."
+    if [ -f /sys/module/nvidia_vgpu_vfio/refcnt ]; then
+        nvidia_vgpu_vfio_refs=$(< /sys/module/nvidia_vgpu_vfio/refcnt)
+        rmmod_args+=("nvidia_vgpu_vfio")
+        ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia/refcnt ]; then
+        nvidia_refs=$(< /sys/module/nvidia/refcnt)
+        rmmod_args+=("nvidia")
+    fi
+
+    # TODO: check if nvidia module is in use by checking refcnt
+
+    if [ ${#rmmod_args[@]} -gt 0 ]; then
+        rmmod ${rmmod_args[@]}
+        if [ "$?" != "0" ]; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+_shutdown() {
+    if _disable_vfs && _unload_driver; then
+        _unmount_rootfs
+        return 0
+    fi
+    echo "Failed to cleanup driver"
+    return 1
+}
+
+build() {
+  echo "build() not implemented"
+}
+
+load() {
+  echo "load() not implemented"
+}
+
+update() {
+  echo "update() not implemented"
+}
+
+init() {
+  trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+  trap "_shutdown" EXIT
+
+  if ! _unload_driver; then
+    echo "Previous NVIDIA driver installation cannot be removed. Exiting"
+    exit 1
+  fi
+  _unmount_rootfs
+  _create_dev_char_directory
+  _set_fw_search_path
+  _install_driver
+  _load_driver || exit 1
+  _mount_rootfs
+  _enable_vfs
+
+  # In certain scenarios, /sys/class/mdev_bus is not populated with the correct list of devices (PFs and possible VFs)  at this point.
+  # Re-run nvdidia-vgpud to ensure /sys/class/mdev_bus is populated correctly. And restart nvidia-vgpu-mgr if previously killed.
+  nvidia-vgpud &
+  pgrep nvidia-vgpu-mgr >/dev/null || (echo "Restarting nvidia-vgpu-mgr after previously killed" && nvidia-vgpu-mgr &)
+
+  set +x
+  echo "Done, now waiting for signal"
+  trap "echo 'Caught signal'; _shutdown; trap - EXIT; exit" HUP INT QUIT PIPE TERM
+
+  while true; do
+      sleep 15
+      pgrep nvidia-vgpu-mgr >/dev/null || (echo "ERROR: nvidia-vgpu-mgr daemon is no longer running. Exiting." && exit 1)
+  done
+}
+
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 COMMAND [ARG...]
+
+Commands:
+  init   [-a | --accept-license]
+  build  [-a | --accept-license]
+  load
+  update [-k | --kernel VERSION] [-s | --sign KEYID] [-t | --tag TAG]
+EOF
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+command=$1; shift
+case "${command}" in
+    init) options=$(getopt -l accept-license -o a -- "$@") ;;
+    build) options=$(getopt -l accept-license,tag: -o a:t -- "$@") ;;
+    load) options="" ;;
+    update) options=$(getopt -l kernel:,sign:,tag: -o k:s:t: -- "$@") ;;
+    *) usage ;;
+esac
+if [ $? -ne 0 ]; then
+    usage
+fi
+eval set -- "${options}"
+
+ACCEPT_LICENSE=""
+KERNEL_VERSION=$(uname -r)
+PRIVATE_KEY=""
+PACKAGE_TAG=""
+
+for opt in ${options}; do
+    case "$opt" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
+    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
+    -s | --sign) PRIVATE_KEY=$2; shift 2 ;;
+    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+    --) shift; break ;;
+    esac
+done
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+$command

--- a/vgpu-manager/rhel9/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel9/ocp_dtk_entrypoint
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+DRIVER_TOOLKIT_SHARED_DIR=/mnt/shared-nvidia-driver-toolkit
+
+nv-ctr-run-with-dtk() {
+    set -x
+
+    if [[ "${RHCOS_IMAGE_MISSING:-}" == "true" ]]; then
+        echo "WARNING: RHCOS '${RHCOS_VERSION:-}' imagetag missing"
+        exit 1
+        # TODO: use entitlement based fallback
+        #exec bash -x nvidia-driver init
+    fi
+
+    if [[ ! -f "$DRIVER_TOOLKIT_SHARED_DIR/dir_prepared" ]]; then
+        cp -r \
+           /usr/local/bin/ocp_dtk_entrypoint \
+           /usr/local/bin/nvidia-driver \
+           /driver \
+           "$DRIVER_TOOLKIT_SHARED_DIR/"
+
+        env | sed 's/=/="/' | sed 's/$/"/' > "$DRIVER_TOOLKIT_SHARED_DIR/env"
+
+        touch "$DRIVER_TOOLKIT_SHARED_DIR/dir_prepared"
+    fi
+
+    set +x
+    while [[ ! -f "$DRIVER_TOOLKIT_SHARED_DIR/driver_build_started" ]]; do
+        if [[ -f "$DRIVER_TOOLKIT_SHARED_DIR/driver_toolkit_broken" ]]; then
+            echo "WARNING: broken driver toolkit detected"
+            exit 1
+            # TODO: use entitlement based fallback
+            #exec bash -x nvidia-driver init
+        fi
+        echo "$(date) Waiting for openshift-driver-toolkit-ctr container to start ..."
+        sleep 15
+    done
+
+    echo "$(date) openshift-driver-toolkit-ctr started."
+
+    # TODO: Currently dtk-build-driver will actually install and load the driver as well.
+    #       Uncomment the following if/when dtk-build-driver only builds precompiled driver.
+    #while [[ ! -f "$DRIVER_TOOLKIT_SHARED_DIR/driver_built" ]]; do
+    #    echo "$(date) Waiting for openshift-driver-toolkit-ctr container to build the precompiled driver ..."
+    #    sleep 15
+    #done
+
+    #echo "$(date) openshift-driver-toolkit-ctr finished building driver."
+    set -x
+    sleep infinity
+}
+
+dtk-build-driver() {
+    if [[ "${RHCOS_IMAGE_MISSING:-}" == "true" ]]; then
+        echo "WARNING: 'istag/driver-toolkit:${RHCOS_VERSION} -n openshift' missing, nothing to do in openshift-driver-toolkit-ctr container"
+        sleep +inf
+    fi
+
+    if ! [[ -f "/lib/modules/$(uname -r)/vmlinuz" ]]; then
+        echo "WARNING: broken Driver Toolkit image detected:"
+        echo "- Node kernel:    $(uname -r)"
+        echo "- Kernel package: $(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-core)"
+
+        # TODO: log entitlement based fallback
+        #echo "INFO: informing nvidia-driver-ctr to fallback on entitled-build."
+        touch "$DRIVER_TOOLKIT_SHARED_DIR/driver_toolkit_broken"
+        echo "INFO: nothing else to do in openshift-driver-toolkit-ctr container, sleeping forever."
+        sleep +inf
+    fi
+
+    # Shared directory is prepared before entering this script. See
+    # 'until [ -f /mnt/shared-nvidia-driver-toolkit/dir_prepared ] ...'
+    # in the Pod command/args
+
+    touch "$DRIVER_TOOLKIT_SHARED_DIR/driver_build_started"
+
+    set -x
+    set -o allexport
+    source "${DRIVER_TOOLKIT_SHARED_DIR}/env"
+    set +o allexport;
+
+    # if this directory already exists,
+    # NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run fails to run
+    # and doesn't create its files. This may happen when the
+    # container fails and restart its execution, leading to
+    # hard-to-understand "unrelated" errors in the following of the script execution
+
+    rm -rf "${DRIVER_TOOLKIT_SHARED_DIR}/driver/NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}";
+
+    mkdir "${DRIVER_TOOLKIT_SHARED_DIR}/bin" -p
+
+    cp -v \
+       "$DRIVER_TOOLKIT_SHARED_DIR/nvidia-driver" \
+       "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
+
+    export PATH="${DRIVER_TOOLKIT_SHARED_DIR}/bin:$PATH";
+
+    # ensure lspci is installed, as 'sriov-manage' script requires it
+    if ! $(lspci >/dev/null); then
+      dnf install -y pciutils && rm -rf /var/cache/yum/*
+    fi
+
+    # upon catching a signal, terminate child process to trigger driver cleanup
+    trap 'echo "Caught signal"; kill "${child_pid}"; wait "${child_pid}"; exit' HUP INT QUIT PIPE TERM
+    cd "${DRIVER_TOOLKIT_SHARED_DIR}/driver";
+    echo "#"
+    echo "# Executing nvidia-driver install script ..."
+    echo "#"
+    bash -x "${DRIVER_TOOLKIT_SHARED_DIR}/nvidia-driver" init &
+
+    child_pid="$!"
+    wait "${child_pid}"
+
+    # TODO: only build driver in the dtk, and let main container load.
+    # 'nvidia-driver init' will only exit if it fails
+    echo "Driver installation failed. Exiting ..."
+    exit 1
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 COMMAND
+
+Commands:
+  dtk-build-driver
+  nv-ctr-run-with-dtk
+EOF
+    exit 1
+}
+if [ $# -eq 0 ]; then
+    usage
+fi
+command=$1; shift
+case "${command}" in
+    dtk-build-driver) options="" ;;
+    nv-ctr-run-with-dtk) options="" ;;
+    *) usage ;;
+esac
+if [ $? -ne 0 ]; then
+    usage
+fi
+eval set -- "${options}"
+
+if ! [ -d "${DRIVER_TOOLKIT_SHARED_DIR:-}" ]; then
+    echo "FATAL: DRIVER_TOOLKIT_SHARED_DIR env variable must be populated with a valid directory"
+    usage
+fi
+
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+$command


### PR DESCRIPTION
Close #453

I used [this RH article](https://access.redhat.com/articles/6907891) as that is the source of truth for RHOCP <> RHCOS matrix.

As per the [supported matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#supported-operating-systems-and-kubernetes-platforms), GPU Operator only support RHOCP 4.14 or later.

I've added extra cases (4.12, 4.13), since some users _might_ be interested in creating drivers for **not** NVIDIA supported environments, that can still receive updates from Red Hat with [Extended Update Support Add-On](https://access.redhat.com/support/policy/updates/openshift). If that is not necessary, I can remove the lines covering 4.12, and 4.13.

Since in [the GPU Operator docs ](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) we do instruct users to export the OS_TAG as per `rhcos4.<x>`, I believe the `Makefile` changes should not brake any existing automation script.

Let me find a lab to test it out, and update accordingly