### PR TITLE
Include lspci in vgpu-manager image and refactoring sriov-manage code

### DIFF
--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -13,6 +13,10 @@ RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
 COPY nvidia-driver /usr/local/bin
 COPY ocp_dtk_entrypoint /usr/local/bin
 
+RUN dnf install -y pciutils && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"

--- a/vgpu-manager/rhel8/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel8/ocp_dtk_entrypoint
@@ -19,6 +19,7 @@ nv-ctr-run-with-dtk() {
         cp -r \
            /usr/local/bin/ocp_dtk_entrypoint \
            /usr/local/bin/nvidia-driver \
+           /usr/bin/lspci \
            /driver \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
 
@@ -94,6 +95,7 @@ dtk-build-driver() {
 
     cp -v \
        "$DRIVER_TOOLKIT_SHARED_DIR/nvidia-driver" \
+       "$DRIVER_TOOLKIT_SHARED_DIR/lspci" \
        "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
 
     export PATH="${DRIVER_TOOLKIT_SHARED_DIR}/bin:$PATH";

--- a/vgpu-manager/rhel9/Dockerfile
+++ b/vgpu-manager/rhel9/Dockerfile
@@ -26,6 +26,10 @@ RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
 COPY nvidia-driver /usr/local/bin
 COPY ocp_dtk_entrypoint /usr/local/bin
 
+RUN dnf install -y pciutils && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"

--- a/vgpu-manager/rhel9/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel9/ocp_dtk_entrypoint
@@ -31,6 +31,7 @@ nv-ctr-run-with-dtk() {
         cp -r \
            /usr/local/bin/ocp_dtk_entrypoint \
            /usr/local/bin/nvidia-driver \
+           /usr/bin/lspci \
            /driver \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
 
@@ -106,6 +107,7 @@ dtk-build-driver() {
 
     cp -v \
        "$DRIVER_TOOLKIT_SHARED_DIR/nvidia-driver" \
+       "$DRIVER_TOOLKIT_SHARED_DIR/lspci" \
        "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
 
     export PATH="${DRIVER_TOOLKIT_SHARED_DIR}/bin:$PATH";


### PR DESCRIPTION
In disconnected environments dnf install cannot be used to install the pciutils package. As the vGPU manager now requires lspci command, this PR adds the lspci functionality along with the sriov-manage code refactoring as dicussed in [#386 ](https://github.com/NVIDIA/gpu-driver-container/pull/386)

- This is a new addition and RHEL 9 specific change under vgpu-manager
- This PR adds pciutils for the lspci support in the image at the build time 
- Refactoring code for sriov-manage to get executed in nvidia-driver container instead of OpenShift Driver toolkit container