### PR TITLE
Add dmidecode and pciutils for nvidia-bug-report.sh diagnostics

### DIFF
--- a/azurelinux/Dockerfile
+++ b/azurelinux/Dockerfile
@@ -10,7 +10,8 @@ USER root
 
 COPY nvidia-driver /usr/local/bin
 
-RUN tdnf -y install util-linux ca-certificates
+# Diagnostic utilities required by nvidia-bug-report.sh
+RUN tdnf -y install util-linux ca-certificates dmidecode pciutils
 
 RUN curl -fsSL -o /etc/yum.repos.d/mariner-nvidia.repo \
      https://raw.githubusercontent.com/microsoft/azurelinux/${AZURE_LINUX_VERSION}/toolkit/docs/nvidia/mariner-nvidia.repo

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -21,6 +21,9 @@ RUN sh /tmp/install.sh depinstall && \
     curl -fsSL -o /usr/local/bin/extract-vmlinux https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux && \
     chmod +x /usr/local/bin/donkey /usr/local/bin/extract-vmlinux
 
+# Diagnostic utilities required by nvidia-bug-report.sh
+RUN yum install -y dmidecode pciutils && rm -rf /var/cache/yum/*
+
 # Install the userspace components and copy the kernel module sources.
 RUN cd /tmp && \
     curl -fSsl -O $BASE_URL/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run && \

--- a/centos8/Dockerfile
+++ b/centos8/Dockerfile
@@ -13,7 +13,9 @@ RUN dnf install -y \
         glibc.i686 \
         make \
         dnf-utils \
-        kmod && \
+        kmod \
+        dmidecode \
+        pciutils && \
     rm -rf /var/cache/dnf/*
 
 RUN curl -fsSL -o /usr/local/bin/donkey https://github.com/3XX0/donkey/releases/download/v1.1.0/donkey && \

--- a/coreos/Dockerfile
+++ b/coreos/Dockerfile
@@ -26,7 +26,9 @@ RUN dpkg --add-architecture i386 && \
         libelf-dev \
 	libssl-dev \
 	module-init-tools \
-	software-properties-common && \
+	software-properties-common \
+	dmidecode \
+	pciutils && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ bionic main" > /etc/apt/sources.list && \

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -74,6 +74,9 @@ RUN sh /tmp/install.sh depinstall && \
     chmod +x /usr/local/bin/donkey /usr/local/bin/extract-vmlinux && \
     ln -s /sbin/ldconfig /sbin/ldconfig.real
 
+# Diagnostic utilities required by nvidia-bug-report.sh
+RUN dnf install -y dmidecode pciutils && rm -rf /var/cache/yum/*
+
 ADD drivers drivers/
 
 # Fetch the installer automatically for passthrough/baremetal types

--- a/flatcar/Dockerfile
+++ b/flatcar/Dockerfile
@@ -20,7 +20,9 @@ RUN dpkg --add-architecture i386 && \
         libelf-dev \
         libssl-dev \
         fdisk \
-        software-properties-common && \
+        software-properties-common \
+        dmidecode \
+        pciutils && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main" > /etc/apt/sources.list && \

--- a/photon3.0/Dockerfile
+++ b/photon3.0/Dockerfile
@@ -11,7 +11,9 @@ RUN tdnf install -y \
 	coreutils \
 	rpm \
 	findutils \
-        kmod && \
+        kmod \
+	dmidecode \
+	pciutils && \
     rm -rf /var/cache/tdnf/*
 
 RUN curl -fsSL -o /usr/local/bin/donkey https://github.com/3XX0/donkey/releases/download/v1.1.0/donkey && \

--- a/rhel7/Dockerfile
+++ b/rhel7/Dockerfile
@@ -10,7 +10,9 @@ RUN yum install -y \
         glibc.i686 \
         make \
         cpio \
-        kmod && \
+        kmod \
+        dmidecode \
+        pciutils && \
     rm -rf /var/cache/yum/*
 
 RUN curl -fsSL -o /usr/local/bin/donkey https://github.com/3XX0/donkey/releases/download/v1.1.0/donkey && \

--- a/rhel8/install.sh
+++ b/rhel8/install.sh
@@ -132,6 +132,9 @@ imex_install() {
 }
 
 extra_pkgs_install() {
+  # Diagnostic utilities required by nvidia-bug-report.sh
+  dnf install -y dmidecode pciutils
+
   if [ "$DRIVER_TYPE" != "vgpu" ]; then
       dnf module enable -y nvidia-driver:${DRIVER_BRANCH}-dkms
 
@@ -141,6 +144,8 @@ extra_pkgs_install() {
       nvlink5_pkgs_install
       imex_install
   fi
+
+  rm -rf /var/cache/yum/*
 }
 
 if [ "$1" = "nvinstall" ]; then

--- a/rhel8/precompiled/Dockerfile
+++ b/rhel8/precompiled/Dockerfile
@@ -90,7 +90,9 @@ RUN echo "${RHEL_VERSION}" > /etc/dnf/vars/releasever \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
     && DRIVER_STREAM=$(echo ${DRIVER_VERSION} | cut -d '.' -f 1) \
     && dnf -y module enable nvidia-driver:${DRIVER_STREAM}/default \
-    && dnf -y install kmod binutils
+    && dnf -y install kmod binutils \
+    # Diagnostic utilities required by nvidia-bug-report.sh
+    && dnf -y install dmidecode pciutils
 
 # Prevent modprobe from giving a WARNING about missing files
 RUN rm -rf /lib/modules/${KERNEL_VERSION} \

--- a/rhel9/install.sh
+++ b/rhel9/install.sh
@@ -143,6 +143,9 @@ imex_install() {
 }
 
 extra_pkgs_install() {
+  # Diagnostic utilities required by nvidia-bug-report.sh
+  dnf install -y dmidecode pciutils
+
   if [ "$DRIVER_TYPE" != "vgpu" ]; then
       dnf module enable -y nvidia-driver:${DRIVER_BRANCH}-dkms
 
@@ -152,6 +155,8 @@ extra_pkgs_install() {
       nvlink5_pkgs_install
       imex_install
   fi
+
+  rm -rf /var/cache/yum/*
 }
 
 setup_cuda_repo() {

--- a/rhel9/precompiled/Dockerfile
+++ b/rhel9/precompiled/Dockerfile
@@ -111,7 +111,9 @@ COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp
 # Kernel packages needed to build drivers / kmod
 RUN echo "${RHEL_VERSION}" > /etc/dnf/vars/releasever \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
-    && dnf -y install kmod binutils
+    && dnf -y install kmod binutils \
+    # Diagnostic utilities required by nvidia-bug-report.sh
+    && dnf -y install dmidecode pciutils
 
 # Prevent modprobe from giving a WARNING about missing files
 RUN rm -rf /lib/modules/${KERNEL_VERSION_NOARCH}.${BUILD_ARCH} \

--- a/sle15/Dockerfile
+++ b/sle15/Dockerfile
@@ -42,6 +42,9 @@ RUN sh /tmp/install.sh depinstall && \
     chmod +x /usr/local/bin/donkey /usr/local/bin/extract-vmlinux && \
     ln -s /sbin/ldconfig /sbin/ldconfig.real
 
+# Diagnostic utilities required by nvidia-bug-report.sh
+RUN zypper --non-interactive install -y dmidecode pciutils && rm -rf /var/cache/zypp/*
+
 ADD drivers drivers/
 
 # Fetch the installer automatically for passthrough/baremetal types

--- a/ubuntu16.04/Dockerfile
+++ b/ubuntu16.04/Dockerfile
@@ -12,7 +12,9 @@ RUN dpkg --add-architecture i386 && \
         curl \
         kmod \
         libc6:i386 \
-        libelf-dev && \
+        libelf-dev \
+        dmidecode \
+        pciutils && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ xenial main universe" > /etc/apt/sources.list && \

--- a/ubuntu18.04/Dockerfile
+++ b/ubuntu18.04/Dockerfile
@@ -26,6 +26,8 @@ RUN dpkg --add-architecture i386 && \
         libelf-dev \
         libglvnd-dev \
         pkg-config \
+        dmidecode \
+        pciutils \
         nvidia-fabricmanager-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 \
         libnvidia-nscq-${DRIVER_BRANCH}=${DRIVER_VERSION}-1 && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -69,6 +69,11 @@ RUN /tmp/install.sh reposetup && /tmp/install.sh depinstall && \
     curl -fsSL -o /usr/local/bin/donkey https://github.com/3XX0/donkey/releases/download/v1.1.0/donkey && \
     chmod +x /usr/local/bin/donkey
 
+# Diagnostic utilities required by nvidia-bug-report.sh
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends dmidecode pciutils && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY nvidia-driver /usr/local/bin
 
 COPY --from=build /work/vgpu-util /usr/local/bin

--- a/ubuntu20.04/precompiled/Dockerfile
+++ b/ubuntu20.04/precompiled/Dockerfile
@@ -23,7 +23,9 @@ RUN dpkg --add-architecture i386 && \
         file \
         libelf-dev \
         libglvnd-dev \
-        pkg-config && \
+        pkg-config \
+        dmidecode \
+        pciutils && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main universe" > /etc/apt/sources.list && \

--- a/ubuntu22.04/install.sh
+++ b/ubuntu22.04/install.sh
@@ -94,17 +94,20 @@ imex_install() {
 }
 
 extra_pkgs_install() {
-  if [ "$DRIVER_TYPE" != "vgpu" ]; then
-      apt-get update
+  apt-get update
 
+  # Diagnostic utilities required by nvidia-bug-report.sh
+  apt-get install -y --no-install-recommends dmidecode pciutils
+
+  if [ "$DRIVER_TYPE" != "vgpu" ]; then
       fabricmanager_install
       nscq_install
       nvsdm_install
       nvlink5_pkgs_install
       imex_install
-
-      rm -rf /var/lib/apt/lists/*
   fi
+
+  rm -rf /var/lib/apt/lists/*
 }
 
 if [ "$1" = "reposetup" ]; then

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -31,7 +31,9 @@ RUN dpkg --add-architecture i386 && \
         file \
         libelf-dev \
         libglvnd-dev \
-        pkg-config && \
+        pkg-config \
+        dmidecode \
+        pciutils && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main universe" > /etc/apt/sources.list && \

--- a/ubuntu24.04/install.sh
+++ b/ubuntu24.04/install.sh
@@ -86,9 +86,12 @@ imex_install() {
 }
 
 extra_pkgs_install() {
-  if [ "$DRIVER_TYPE" != "vgpu" ]; then
-      apt-get update
+  apt-get update
 
+  # Diagnostic utilities required by nvidia-bug-report.sh
+  apt-get install -y --no-install-recommends dmidecode pciutils
+
+  if [ "$DRIVER_TYPE" != "vgpu" ]; then
       fabricmanager_install
       nscq_install
 
@@ -100,9 +103,9 @@ extra_pkgs_install() {
 
       nvlink5_pkgs_install
       imex_install
-
-      rm -rf /var/lib/apt/lists/*
   fi
+
+  rm -rf /var/lib/apt/lists/*
 }
 
 if [ "$1" = "depinstall" ]; then

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -28,7 +28,9 @@ RUN dpkg --add-architecture i386 && \
         file \
         libelf-dev \
         libglvnd-dev \
-        pkg-config && \
+        pkg-config \
+        dmidecode \
+        pciutils && \
     rm -rf /var/lib/apt/lists/*
 
 # Fetch GPG keys for CUDA repo

--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -5,6 +5,9 @@ ENV DRIVER_VERSION=$DRIVER_VERSION
 ARG DRIVER_ARCH=x86_64
 ENV DRIVER_ARCH=$DRIVER_ARCH
 
+# Diagnostic utilities required by nvidia-bug-report.sh
+RUN dnf install -y dmidecode pciutils && rm -rf /var/cache/yum/*
+
 RUN mkdir -p /driver
 WORKDIR /driver
 COPY NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run .

--- a/vgpu-manager/ubuntu20.04/Dockerfile
+++ b/vgpu-manager/ubuntu20.04/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         file \
         kmod \
+        dmidecode \
         pciutils && \
     rm -rf /var/lib/apt/lists/*
 

--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         file \
         kmod \
+        dmidecode \
         pciutils && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Adds `dmidecode` and `pciutils` packages to all driver container images to enable complete `nvidia-bug-report.sh` output.

## Problem
Users report `nvidia-bug-report.sh` script requires `lspci` (from pciutils) and `dmidecode` to collect full system diagnostics. These utilities were missing from the driver container images, resulting in incomplete bug reports.

## Changes
- Updated `extra_pkgs_install()` in install.sh files (ubuntu22.04, ubuntu24.04, rhel8, rhel9). 

Note: I chose to place them here because these are runtime diagnostic utilities (not build dependencies), and by adding them outside the DRIVER_TYPE != "vgpu" condition, they are installed for all driver types including vGPU.

- Added packages to Dockerfiles for all other distros and precompiled/vgpu-manager variants

