### PR TITLE
use go.dev to download go archive files

### DIFF
--- a/coreos/Dockerfile
+++ b/coreos/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvcr.io/nvidia/cuda:13.0.1-base-ubi8 as license
 
 # Build nvidia-container-runtime binary
-FROM golang:1.25.2 as build-runtime
+FROM golang:1.25.5 as build-runtime
 
 WORKDIR /go/src/nvidia-container-runtime
 COPY nvidia-container-runtime .

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y git wget
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV PATH /usr/local/go/bin:$PATH

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf install -y git wget
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV PATH /usr/local/go/bin:$PATH

--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -15,12 +15,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         curl \
-        git && \
+        git  \
+        wget && \
     rm -rf /var/lib/apt/lists/*
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV PATH /usr/local/go/bin:$PATH

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -19,12 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         curl \
-        git && \
+        git  \
+        wget && \
     rm -rf /var/lib/apt/lists/*
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV PATH /usr/local/go/bin:$PATH

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -21,14 +21,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         curl \
-        git && \
+        git  \
+        wget && \
     rm -rf /var/lib/apt/lists/*
 
 
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV PATH /usr/local/go/bin:$PATH

--- a/versions.mk
+++ b/versions.mk
@@ -15,4 +15,4 @@
 # DRIVER_VERSIONS contains latest version in all active datacenter branches
 DRIVER_VERSIONS ?= 535.274.02 570.195.03 580.105.08
 
-GOLANG_VERSION := 1.25.4
+GOLANG_VERSION := 1.25.5


### PR DESCRIPTION
This PR also bumps the go version to `1.25.5`

NOTE: `go.dev` redirects to another link before returning 200, so we switch from `curl` to `wget` in order to handle this