### PR TITLE
add azure-fde to the list of precompiled kernel flavours

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -102,7 +102,7 @@ trigger-pipeline:
   parallel:
     matrix:
       - DRIVER_BRANCH: [570, 580]
-        KERNEL_FLAVOR: [aws, azure, generic, nvidia, oracle]
+        KERNEL_FLAVOR: [aws, azure, azure-fde, generic, nvidia, oracle]
         LTS_KERNEL: ["6.8"]
 
 .dist-ubuntu22.04:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -101,6 +101,7 @@ jobs:
         flavor:
           - aws
           - azure
+          - azure-fde
           - generic
           - nvidia
           - oracle
@@ -125,6 +126,8 @@ jobs:
             dist: ubuntu24.04
           - lts_kernel: 5.15
             dist: ubuntu24.04
+          - flavor: azure-fde
+            dist: ubuntu22.04
     steps:
       - uses: actions/checkout@v5
         name: Check out code

--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -39,7 +39,7 @@ jobs:
           echo "driver_branch=$driver_branch_json" >> $GITHUB_OUTPUT
 
           # get kernel flavors
-          KERNEL_FLAVORS=("aws" "azure" "generic" "nvidia" "oracle")
+          KERNEL_FLAVORS=("aws" "azure" "azure-fde" "generic" "nvidia" "oracle")
           kernel_flavors_json=$(printf '%s\n' "${KERNEL_FLAVORS[@]}" | jq -R . | jq -cs .)
           echo "kernel_flavors=$kernel_flavors_json" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
New images created from this PR

- `ghcr.io/nvidia/driver:17028ae9-570-6.8.0-1044-azure-fde-ubuntu24.04`
- `ghcr.io/nvidia/driver:17028ae9-580-6.8.0-1044-azure-fde-ubuntu24.04`
