### PR TITLE
[precompiled-e2e][gh-action] add kernel flavour to the strategy matrix

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -172,6 +172,7 @@ jobs:
       matrix:
         dist: ${{ fromJson(needs.set-driver-version-matrix.outputs.dist) }}
         lts_kernel: ${{ fromJson(needs.set-driver-version-matrix.outputs.lts_kernel) }}
+        flavor: ${{ fromJson(needs.set-driver-version-matrix.outputs.kernel_flavors) }}
         exclude:
           - lts_kernel: 5.15
             dist: ubuntu24.04


### PR DESCRIPTION
This PR allows exclusion of certain parameter sets by the kernel flavour as intended in PR #502 