### PR TITLE
[holodeck][ubuntu] update AMI IDs to ensure an LTS kernel is used

### DIFF
--- a/tests/holodeck_ubuntu22.04.yaml
+++ b/tests/holodeck_ubuntu22.04.yaml
@@ -23,7 +23,7 @@ spec:
     - 44.230.241.223/32
     image:
       architecture: amd64
-      imageId: ami-0ce2cb35386fc22e9
+      imageId: ami-0007a86be89339c9f
   containerRuntime:
     install: true
     name: containerd

--- a/tests/holodeck_ubuntu24.04.yaml
+++ b/tests/holodeck_ubuntu24.04.yaml
@@ -23,7 +23,7 @@ spec:
     - 44.230.241.223/32
     image:
       architecture: amd64
-      imageId: ami-0da424eb883458071
+      imageId: ami-00271c85bf8a52b84
   containerRuntime:
     install: true
     name: containerd


### PR DESCRIPTION
Ubuntu 22.04 - `ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20251122-47489723-7305-4e22-8b22-b0d57054f216` **ami-0007a86be89339c9f**

Ubuntu 24.04 - `ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250821` **ami-00271c85bf8a52b84**