### PR TITLE
[precompiled-e2e][ci] improve kernel flavour substring extraction sed statement

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -432,7 +432,7 @@ jobs:
         if: ${{ ! (matrix.driver_branch == 535 && contains(matrix.kernel_version, 'ubuntu24.04')) }}
         run: |
           LTS_KERNEL=$(echo "${{ matrix.kernel_version }}" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
-          KERNEL_FLAVOR=$(echo "${{ matrix.kernel_version }}" | sed -E 's/^.*-[0-9]+-([a-zA-Z]+)-.*/\1/')
+          KERNEL_FLAVOR=$(echo "${{ matrix.kernel_version }}" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-(.*)-ubuntu[0-9]+\.[0-9]+$/\1/')
           DIST=$(echo "${{ matrix.kernel_version }}" | sed -E 's/^.*-(ubuntu[0-9]+\.[0-9]+)$/\1/')
           if [[ "${DIST}" == "ubuntu22.04" ]]; then
             BASE_TARGET="jammy"


### PR DESCRIPTION
This PR addresses the CI failure observed [here](https://github.com/NVIDIA/gpu-driver-container/actions/runs/20195575187/job/57981418055)

The current sed statement does not account for kernel flavour names delimited by `-`. For e.g:- `azure-fde`, `nvidia-64k`

 