### PR TITLE
Update repository URLs to use HTTPS

### DIFF
--- a/ubuntu22.04/install.sh
+++ b/ubuntu22.04/install.sh
@@ -37,14 +37,14 @@ dep_install () {
 
 repo_setup () {
     if [ "$TARGETARCH" = "amd64" ]; then
-        echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main universe" > /etc/apt/sources.list && \
-        echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main universe" >> /etc/apt/sources.list && \
-        echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main universe" >> /etc/apt/sources.list && \
+        echo "deb [arch=amd64] https://archive.ubuntu.com/ubuntu/ jammy main universe" > /etc/apt/sources.list && \
+        echo "deb [arch=amd64] https://archive.ubuntu.com/ubuntu/ jammy-updates main universe" >> /etc/apt/sources.list && \
+        echo "deb [arch=amd64] https://archive.ubuntu.com/ubuntu/ jammy-security main universe" >> /etc/apt/sources.list && \
         usermod -o -u 0 -g 0 _apt
     elif [ "$TARGETARCH" = "arm64" ]; then
-        echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe" > /etc/apt/sources.list && \
-        echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe" >> /etc/apt/sources.list && \
-        echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe" >> /etc/apt/sources.list && \
+        echo "deb [arch=arm64] https://ports.ubuntu.com/ubuntu-ports jammy main universe" > /etc/apt/sources.list && \
+        echo "deb [arch=arm64] https://ports.ubuntu.com/ubuntu-ports jammy-updates main universe" >> /etc/apt/sources.list && \
+        echo "deb [arch=arm64] https://ports.ubuntu.com/ubuntu-ports jammy-security main universe" >> /etc/apt/sources.list && \
         usermod -o -u 0 -g 0 _apt
     else
         echo "TARGETARCH doesn't match a known arch target"


### PR DESCRIPTION
## Overview
This PR addresses the usage of HTTP for repository URLs in the script. Currently, the script uses HTTP for fetching packages from Ubuntu repositories, and i'm uncertain whether this choice was intentional.

## Changes
- Replaced HTTP URLs with HTTPS URLs for Ubuntu package repositories in the `repo_setup` function.

## Motivation and Context
The primary motivation for this change is to improve security by migrating to HTTPS, which ensures that all communication with the repository is encrypted. This is especially important for protecting the integrity and authenticity of the packages being downloaded.

Although HTTP still works, it lacks the encryption layer provided by HTTPS, which makes it vulnerable to interception and tampering. Migrating to HTTPS ensures that the system is protected from these security risks.

Additionally, some **air-gapped environments** or highly restricted networks may block **outbound HTTP traffic on port 80**, which could prevent the script from successfully fetching packages. In such cases, using HTTPS (typically over port 443) is often the only available option to access external repositories. Migrating to HTTPS ensures compatibility with these environments.

If maintaining HTTP support is still desired, I can modify the script to offer the option to use either HTTP or HTTPS, based on user preference.