### PR TITLE
update lspci path in vgpu-manager for RHEL

### DIFF
--- a/vgpu-manager/rhel8/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel8/ocp_dtk_entrypoint
@@ -19,7 +19,7 @@ nv-ctr-run-with-dtk() {
         cp -r \
            /usr/local/bin/ocp_dtk_entrypoint \
            /usr/local/bin/nvidia-driver \
-           /usr/bin/lspci \
+           /usr/sbin/lspci \
            /driver \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
 

--- a/vgpu-manager/rhel9/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel9/ocp_dtk_entrypoint
@@ -31,7 +31,7 @@ nv-ctr-run-with-dtk() {
         cp -r \
            /usr/local/bin/ocp_dtk_entrypoint \
            /usr/local/bin/nvidia-driver \
-           /usr/bin/lspci \
+           /usr/sbin/lspci \
            /driver \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
 


### PR DESCRIPTION
This PR corrects the file path used to locate the `lspci` utility within the `vgpu-manager` entrypoint script (`ocp_dtk_entrypoint`).
Currently it tries to copy lscpi from /usr/bin
While on RHEL it is located in /usr/sbin

Tested this while building vgpu manager image 
The following error occurs during the nvidia-vgpu-manager-daemonset initialization
`+ cp -r /usr/local/bin/ocp_dtk_entrypoint /usr/local/bin/nvidia-driver /usr/bin/lspci /driver /mnt/shared-nvidia-driver-toolkit/
cp: cannot stat '/usr/bin/lspci': No such file or directory`

which is fixed when path is changed to /usr/sbin/lspci