### PR TITLE
[feat] : store additional drivers enabled/disabled list on host

### DIFF
--- a/azurelinux/nvidia-driver
+++ b/azurelinux/nvidia-driver
@@ -265,10 +265,26 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 _load() {
     _install_driver
     _load_driver
     _mount_rootfs
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/centos7/nvidia-driver
+++ b/centos7/nvidia-driver
@@ -410,6 +410,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -440,6 +455,7 @@ init() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/centos8/nvidia-driver
+++ b/centos8/nvidia-driver
@@ -274,6 +274,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -304,6 +319,7 @@ init() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/coreos/nvidia-driver
+++ b/coreos/nvidia-driver
@@ -250,6 +250,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -275,6 +290,7 @@ init() {
     _install_driver
     _load_driver
     _mount_rootfs
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/fedora/nvidia-driver
+++ b/fedora/nvidia-driver
@@ -644,10 +644,26 @@ _build() {
     _install_driver
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 _load() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/flatcar/nvidia-driver
+++ b/flatcar/nvidia-driver
@@ -366,6 +366,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     printf "\\n========== NVIDIA Software Installer ==========\\n"
     printf "Starting installation of NVIDIA driver version %s for Linux kernel version %s\\n" "${DRIVER_VERSION}" "${KERNEL_VERSION}"
@@ -391,6 +406,7 @@ init() {
     _install_driver
     _load_driver
     _mount_rootfs
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/photon3.0/nvidia-driver
+++ b/photon3.0/nvidia-driver
@@ -260,6 +260,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -290,6 +305,7 @@ init() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/rhel7/nvidia-driver
+++ b/rhel7/nvidia-driver
@@ -295,6 +295,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -325,6 +340,7 @@ init() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -737,10 +737,26 @@ _build() {
     _install_driver
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 _load() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -754,10 +754,26 @@ _build() {
     _install_driver
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 _load() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/sle15/nvidia-driver
+++ b/sle15/nvidia-driver
@@ -419,6 +419,21 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     if [ "${DRIVER_TYPE}" = "vgpu" ]; then
         _find_vgpu_driver_version || exit 1
@@ -464,6 +479,7 @@ init() {
     _load_driver || exit 1
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/ubuntu16.04/nvidia-driver
+++ b/ubuntu16.04/nvidia-driver
@@ -277,6 +277,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -307,6 +322,7 @@ init() {
     _load_driver
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/ubuntu18.04/nvidia-driver
+++ b/ubuntu18.04/nvidia-driver
@@ -348,6 +348,21 @@ _shutdown() {
     return 1
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     echo -e "\n========== NVIDIA Software Installer ==========\n"
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}\n"
@@ -378,6 +393,7 @@ init() {
     _load_driver || exit 1
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/ubuntu20.04/nvidia-driver
+++ b/ubuntu20.04/nvidia-driver
@@ -561,6 +561,21 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     if [ "${DRIVER_TYPE}" = "vgpu" ]; then
         _find_vgpu_driver_version || exit 1
@@ -621,6 +636,7 @@ init() {
     _load_driver || exit 1
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -638,6 +638,21 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     if [ "${DRIVER_TYPE}" = "vgpu" ]; then
         _find_vgpu_driver_version || exit 1
@@ -699,6 +714,7 @@ init() {
     _load_driver || exit 1
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -566,6 +566,21 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_build_features_config() {
+    cat <<EOF
+GDRCOPY_ENABLED: ${GDRCOPY_ENABLED:-false}
+GDS_ENABLED: ${GDS_ENABLED:-false}
+GPU_DIRECT_RDMA_ENABLED: ${GPU_DIRECT_RDMA_ENABLED:-false}
+EOF
+}
+
+_store_additional_drivers_flags() {
+    local config_file="${RUN_DIR}/driver/.additional-drivers-flags"
+    echo "Storing additional drivers flags..."
+    _build_features_config > "$config_file"
+    echo "Additional drivers flags stored at $config_file"
+}
+
 init() {
     if [ "${DRIVER_TYPE}" = "vgpu" ]; then
         _find_vgpu_driver_version || exit 1
@@ -600,6 +615,7 @@ init() {
     _load_driver || exit 1
     _mount_rootfs
     _write_kernel_update_hook
+    _store_additional_drivers_flags
 
     echo "Done, now waiting for signal"
     sleep infinity &


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
This PR adds the ability for driver container to write a file on host containing the env vars listing which additional drivers are enabled on the host.
This list can be used by other operands like nvidia-validator which can read this file and make sure all the listed additional drivers are installed before continuing with next steps.
## Checklist

- [x] No secrets, sensitive information, or unrelated changes

## Testing

<!-- How was this tested? e.g., unit tests, manual testing on cluster -->

- [ ] Unit tests
- [ ] Manual cluster testing (describe below)
- [ ] N/A or Other (docs, CI config, etc.)

**Test details:**