### PR TITLE
[rhel8] set shellopts to ensure scripts exits on failure

### DIFF
--- a/rhel8/install.sh
+++ b/rhel8/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 
+set -eu
+
 DRIVER_ARCH=${TARGETARCH/amd64/x86_64} && DRIVER_ARCH=${DRIVER_ARCH/arm64/aarch64}
 echo "DRIVER_ARCH is $DRIVER_ARCH"
 


### PR DESCRIPTION
This makes the `rhel8` consistent with the other OS directories