### PR TITLE
Check SELinux enforce state instead of selinuxfs existence

### DIFF
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -576,7 +576,7 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if [ "$(cat /sys/fs/selinux/enforce 2>/dev/null)" = "1" ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev

--- a/rhel9/precompiled/nvidia-driver
+++ b/rhel9/precompiled/nvidia-driver
@@ -343,7 +343,7 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if [ "$(cat /sys/fs/selinux/enforce 2>/dev/null)" = "1" ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev


### PR DESCRIPTION
Resolves https://github.com/NVIDIA/gpu-operator/issues/1489. 

## Problem
The previous check [ `-e /sys/fs/selinux `] returns true even when SELinux is in permissive mode or disabled, causing unnecessary `chcon` calls on systems where SELinux isn't enforcing.

## Solution
Read the enforce state directly: `cat /sys/fs/selinux/enforce` returns 1 only when SELinux is actively enforcing. This aligns RHEL9 detection with the correct behavior.

**NOTE**: Implemented only for RHEL 9 right now.  I'll update other distros (RHEL 7/8, Fedora, Azure Linux) after an initial approval.

## Testing

### Environment
- RHEL 9.2 kernel (`5.14.0-284.43.1.el9_2.x86_64`)
- 2x NVIDIA A40
- Image: `ghcr.io/karthikvetrivel/driver:570.195.03-rhel9.6`

### Test Results

| SELinux State | `enforce` value | Detection Output | Status |
|---------------|-----------------|------------------|--------|
| Enforcing | 1 | "SELinux is enabled" (runs chcon) | PASS |
| Permissive | 0 | "SELinux is disabled, skipping..." | PASS |

### Verification
- Driver loads successfully (`nvidia-smi` works)
- No chcon errors in logs
- Container exits cleanly