### PR TITLE
Add SUBDIR mapping for vgpu rhel9.x targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ build-vgpuguest-%: DRIVER_TAG = $(DRIVER_VERSION:-grid=)
 
 # Source of truth for RHEL and CoreOS compatibility https://access.redhat.com/articles/6907891
 build-vgpuguest-rhcos%: SUBDIR = rhel9
+build-vgpuguest-rhel9%: SUBDIR = rhel9
 
 
 $(VGPU_GUEST_DRIVER_BUILD_TARGETS):
@@ -285,6 +286,7 @@ build-vgpuhost-%: DOCKERFILE = $(CURDIR)/vgpu-manager/$(SUBDIR)/Dockerfile
 
 # Source of truth for RHEL and CoreOS compatibility https://access.redhat.com/articles/6907891
 build-vgpuhost-rhcos%: SUBDIR = rhel9
+build-vgpuhost-rhel9%: SUBDIR = rhel9
 
 $(VGPU_HOST_DRIVER_BUILD_TARGETS):
 	DOCKER_BUILDKIT=1 \


### PR DESCRIPTION
Close #494 .

On main, rhel9.6 targets resolve to the wrong subdirectory (`rhel9.6/` instead of `rhel9/`), as reported in #486.

Steps from [cloud-native docs](https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/openshift-virtualization.html#nvidia-gpu-operator-with-openshift-virtualization).

Before the fix (on main):
```
 $ git log -1 --pretty=oneline
b36127925fece95b9e2edcc55d0dcd8e42636cdb (HEAD -> main, origin/main, origin/HEAD) Merge pull request #564 from NVIDIA/dependabot/github_actions/renovatebot/github-action-44.2.5
 $ export PRIVATE_REGISTRY=my.private.registry.example.com VGPU_HOST_DRIVER_VERSION=570.211.01 OS_TAG=rhel9.6
 $ GPU_HOST_DRIVER_VERSION=${VGPU_HOST_DRIVER_VERSION} IMAGE_NAME=${PRIVATE_REGISTRY}/vgpu-manager make build-vgpuhost-${OS_TAG}
DOCKER_BUILDKIT=1 \
        docker  build --pull \
                        --output=type=image,push=false \
                        --platform=linux/amd64 \
                        --tag my.private.registry.example.com/vgpu-manager:570.211.01-rhel9.6 \
                        --build-arg DRIVER_BRANCH="570" \
                        --build-arg DRIVER_VERSION="570.211.01" \
                        --build-arg GOLANG_VERSION="1.25.6" \
                        --build-arg CVE_UPDATES="" \
                        --build-arg CUDA_VERSION="" \
                         \
                        --file /home/user/gpu-driver-container/vgpu-manager/rhel9.6/Dockerfile \
                        /home/user/gpu-driver-container/vgpu-manager/rhel9.6
[+] Building 0.0s (0/0)                                                                                                                                                                        docker:default
ERROR: failed to build: unable to prepare context: path "/home/user/gpu-driver-container/vgpu-manager/rhel9.6" not found
make: *** [Makefile:290: build-vgpuhost-rhel9.6] Error 1
```

After the fix:
```
$ export PRIVATE_REGISTRY=my.private.registry.example.com VGPU_HOST_DRIVER_VERSION=570.211.01 OS_TAG=rhel9.6
 $ VGPU_HOST_DRIVER_VERSION=${VGPU_HOST_DRIVER_VERSION} IMAGE_NAME=${PRIVATE_REGISTRY}/vgpu-manager make build-vgpuhost-${OS_TAG}
[+] Building 0.7s (15/15) FINISHED
 => => writing image sha256:25bd786d611d404401e1deb2c10b4df172d8459b2dc5e7d50e2aad2419f0f9bf
 => => naming to my.private.registry.example.com/vgpu-manager:570.211.01-rhel9.6

$ docker image ls --no-trunc --format '{{.ID}}' my.private.registry.example.com/vgpu-manager:570.211.01-rhel9.6
sha256:25bd786d611d404401e1deb2c10b4df172d8459b2dc5e7d50e2aad2419f0f9bf
```