### PR TITLE
fix: load video module for RHEL 9.3+ in precompiled case

### DIFF
--- a/rhel9/precompiled/nvidia-driver
+++ b/rhel9/precompiled/nvidia-driver
@@ -17,6 +17,7 @@ USE_HOST_MOFED="${USE_HOST_MOFED:-false}"
 DNF_RELEASEVER=${DNF_RELEASEVER:-""}
 RHEL_VERSION=${RHEL_VERSION:-""}
 RHEL_MAJOR_VERSION=9
+RHEL_MINOR_VERSION=${RHEL_MINOR_VERSION:-""}
 MODPROBE_CONFIG_DIR="/etc/modprobe.d"
 
 DRIVER_ARCH=${TARGETARCH/amd64/x86_64} && DRIVER_ARCH=${DRIVER_ARCH/arm64/aarch64}
@@ -57,6 +58,7 @@ _get_rhel_version_from_kernel() {
         return 1
     fi
     RHEL_VERSION="${rhel_version_arr[0]}.${rhel_version_arr[1]}"
+    RHEL_MINOR_VERSION=${rhel_version_arr[1]}
     echo "RHEL VERSION successfully resolved from kernel: ${RHEL_VERSION}"
     return 0
 }
@@ -208,6 +210,11 @@ _load_driver() {
             mkdir -p $nv_fw_search_path/nvidia/${DRIVER_VERSION}
             cp /opt/lib/firmware/nvidia/${DRIVER_VERSION}/gsp_*.bin $nv_fw_search_path/nvidia/${DRIVER_VERSION}
         fi
+    fi
+
+    if [[ "$RHEL_MINOR_VERSION" -ge "3" ]]; then
+        echo "Loading the video kernel module..."
+        modprobe video
     fi
 
     echo "Loading NVIDIA driver kernel modules..."


### PR DESCRIPTION
The non-precompiled nvidia-driver script alread catches the case of RHEL 9.3+ where RTX cards require the video driver to be able to load the nvidia_modeset module. This commit adds the same feature to precompiled driver container image.