### PR TITLE
[fix] : update cache before running install

### DIFF
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -39,7 +39,11 @@ _enable_fips_if_required() {
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
-        apt-get -qq update
+        if ! apt-get -qq update; then
+            echo "ERROR: Failed to update package cache. "\
+                 "Ensure that the cluster can access the proper networks."
+            exit 1
+        fi
     fi
 }
 

--- a/ubuntu22.04/precompiled/nvidia-driver
+++ b/ubuntu22.04/precompiled/nvidia-driver
@@ -62,7 +62,11 @@ nvsdm_install() {
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
-        apt-get -qq update
+        if ! apt-get -qq update; then
+            echo "ERROR: Failed to update package cache. "\
+                 "Ensure that the cluster can access the proper networks."
+            exit 1
+        fi
     fi
 }
 
@@ -449,6 +453,8 @@ init() {
 
     _unload_driver || exit 1
     _unmount_rootfs
+
+    _update_package_cache
 
     _create_module_params_conf
     _install_driver

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -49,7 +49,11 @@ _enable_fips_if_required() {
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
-        apt-get -qq update
+        if ! apt-get -qq update; then
+            echo "ERROR: Failed to update package cache. "\
+                 "Ensure that the cluster can access the proper networks."
+            exit 1
+        fi
     fi
 }
 

--- a/ubuntu24.04/precompiled/nvidia-driver
+++ b/ubuntu24.04/precompiled/nvidia-driver
@@ -63,7 +63,11 @@ nvsdm_install() {
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
-        apt-get -qq update
+        if ! apt-get -qq update; then
+            echo "ERROR: Failed to update package cache. "\
+                 "Ensure that the cluster can access the proper networks."
+            exit 1
+        fi
     fi
 }
 
@@ -450,6 +454,8 @@ init() {
 
     _unload_driver || exit 1
     _unmount_rootfs
+
+    _update_package_cache
 
     _create_module_params_conf
     _install_driver


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/gpu-operator/issues/1244

### Root cause
Package versions are rotated/updated on mirrors over time. The _install_driver() function in the nvidia-driver script was calling `apt-get install` without first running `apt-get update`. This meant it was using stale package lists that referenced package versions (like python3.10_3.10.12-1~22.04.7) that had been rotated out of the Ubuntu repositories in favor of newer/patched versions. This resulted in 404 errors when fetching those stale packages and install script exited with error.

### Fix
The fix proposes running `apt-get update` before running any `apt install`.