### PR TITLE
[ubuntu] only upgrade specific packages when CVE_UPDATES is specified

### DIFF
--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -104,7 +104,7 @@ RUN apt-get update && \
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -fsSL -o /usr/local/bin/donkey https://github.com/3XX0/donkey/releases/
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -92,7 +92,7 @@ WORKDIR  /drivers
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -42,7 +42,7 @@ RUN usermod -o -u 0 -g 0 _apt
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -40,7 +40,7 @@ COPY nvidia-driver /usr/local/bin
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/vgpu-manager/ubuntu24.04/Dockerfile
+++ b/vgpu-manager/ubuntu24.04/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod +x /usr/local/bin/nvidia-driver
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 


### PR DESCRIPTION
This fixes a bug in the `CVE_UPDATES` logic of the ubuntu  images. To upgrade specific packages as originally intended, we need to use `apt install --upgrade-only <package-name1> <package-name2>...` instead of `apt upgrade <package-name1> <package-name2>...`

From the apt manual
```
       upgrade
           upgrade is used to install the newest versions of all packages currently installed on the system from the sources enumerated in /etc/apt/sources.list. Packages currently installed with new versions available are retrieved
           and upgraded; under no circumstances are currently installed packages removed, or packages not already installed retrieved and installed. New versions of currently installed packages that cannot be upgraded without changing
           the install status of another package will be left at their current version. An update must be performed first so that apt-get knows that new versions of packages are available.

           When a package is supplied as an argument, the package will be installed prior to the upgrade action.
```