### PR TITLE
[ubuntu] Support non-standard kernel version naming

### DIFF
--- a/ubuntu16.04/nvidia-driver
+++ b/ubuntu16.04/nvidia-driver
@@ -26,16 +26,25 @@ _cleanup_package_cache() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/ubuntu18.04/nvidia-driver
+++ b/ubuntu18.04/nvidia-driver
@@ -29,16 +29,25 @@ _cleanup_package_cache() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/ubuntu20.04/nvidia-driver
+++ b/ubuntu20.04/nvidia-driver
@@ -46,16 +46,25 @@ _update_ca_certificates() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -62,16 +62,25 @@ _update_ca_certificates() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -72,16 +72,25 @@ _update_ca_certificates() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/vgpu-manager/ubuntu20.04/nvidia-driver
+++ b/vgpu-manager/ubuntu20.04/nvidia-driver
@@ -27,16 +27,25 @@ _cleanup_package_cache() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/vgpu-manager/ubuntu22.04/nvidia-driver
+++ b/vgpu-manager/ubuntu22.04/nvidia-driver
@@ -29,16 +29,25 @@ _cleanup_package_cache() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"

--- a/vgpu-manager/ubuntu24.04/nvidia-driver
+++ b/vgpu-manager/ubuntu24.04/nvidia-driver
@@ -29,16 +29,25 @@ _cleanup_package_cache() {
 
 # Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
 _resolve_kernel_version() {
-    local version=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null | \
-      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+).*/\1-\3/p' | head -1)
-    local kernel_flavor=$(echo ${KERNEL_VERSION} | sed 's/[^a-z]*//')
-    kernel_flavor="${kernel_flavor//virtual/generic}"
-
     echo "Resolving Linux kernel version..."
-    if [ -z "${version}" ]; then
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
         echo "Could not resolve Linux kernel version" >&2
         return 1
     fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
 
     KERNEL_VERSION="${version}-${kernel_flavor}"
     echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"


### PR DESCRIPTION
Query apt-cache for linux-headers package info once and attempt to parse the version using the existing major.minor.patch-revision regex. When the regex does not match (e.g. custom/distro kernels with non-standard naming), keep KERNEL_VERSION unchanged instead of failing. This preserves the existing resolution logic for standard Ubuntu kernels while allowing custom kernels to work without modification.

Applied to all Ubuntu/Debian variants and vgpu-manager Ubuntu variants.

Closes: https://github.com/NVIDIA/gpu-driver-container/issues/601