### PR TITLE
Updates to vGPU Manager build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ $(DRIVER_BUILD_TARGETS):
 				$(CURDIR)/$(SUBDIR)
 
 build-rhcos%: SUBDIR = rhel9
+build-rhel9%: SUBDIR = rhel9
 
 build-rocky9%: SUBDIR = rhel9
 build-rocky9%: DOCKER_BUILD_ARGS = --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:13.1.1-base-rockylinux9
@@ -249,6 +250,7 @@ build-vgpuguest-%: DRIVER_TAG = $(DRIVER_VERSION:-grid=)
 
 # Source of truth for RHEL and CoreOS compatibility https://access.redhat.com/articles/6907891
 build-vgpuguest-rhcos%: SUBDIR = rhel9
+build-vgpuguest-rhel9%: SUBDIR = rhel9
 
 
 $(VGPU_GUEST_DRIVER_BUILD_TARGETS):
@@ -288,6 +290,7 @@ build-vgpuhost-%: DOCKERFILE = $(CURDIR)/vgpu-manager/$(SUBDIR)/Dockerfile
 
 # Source of truth for RHEL and CoreOS compatibility https://access.redhat.com/articles/6907891
 build-vgpuhost-rhcos%: SUBDIR = rhel9
+build-vgpuhost-rhel9%: SUBDIR = rhel9
 
 $(VGPU_HOST_DRIVER_BUILD_TARGETS):
 	DOCKER_BUILDKIT=1 \

--- a/vgpu-manager/rhel9/ocp_dtk_entrypoint
+++ b/vgpu-manager/rhel9/ocp_dtk_entrypoint
@@ -32,8 +32,14 @@ nv-ctr-run-with-dtk() {
            /usr/local/bin/ocp_dtk_entrypoint \
            /usr/local/bin/nvidia-driver \
            /usr/sbin/lspci \
+           /usr/sbin/setpci \
            /driver \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
+
+        # Copy pciutils library dependencies for the DTK container
+        # (the DTK image does not have libpci, and dnf fallback fails in air-gapped networks)
+        mkdir -p "$DRIVER_TOOLKIT_SHARED_DIR/lib64"
+        cp /usr/lib64/libpci.so* "$DRIVER_TOOLKIT_SHARED_DIR/lib64/"
 
         env | sed 's/=/="/' | sed 's/$/"/' > "$DRIVER_TOOLKIT_SHARED_DIR/env"
 
@@ -108,9 +114,11 @@ dtk-build-driver() {
     cp -v \
        "$DRIVER_TOOLKIT_SHARED_DIR/nvidia-driver" \
        "$DRIVER_TOOLKIT_SHARED_DIR/lspci" \
+       "$DRIVER_TOOLKIT_SHARED_DIR/setpci" \
        "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
 
     export PATH="${DRIVER_TOOLKIT_SHARED_DIR}/bin:$PATH";
+    export LD_LIBRARY_PATH="${DRIVER_TOOLKIT_SHARED_DIR}/lib64:${LD_LIBRARY_PATH:-}";
 
     # ensure lspci is installed, as 'sriov-manage' script requires it
     if ! $(lspci >/dev/null); then


### PR DESCRIPTION
Fix vGPU Manager build for OCP 4.19+ and pciutils availability in air-gapped environments

The documented OS_TAG=rhel9.6 for OpenShift 4.19+ fails because the Makefile SUBDIR overrides only match the "rhcos" prefix, not "rhel9". Add SUBDIR mappings for rhel9-prefixed targets across driver, vgpu-guest, and vgpu-host build targets.

The ocp_dtk_entrypoint script copies the lspci binary to the shared directory for the DTK container, but does not copy its library dependency (libpci.so) or the setpci binary also required by sriov-manage. In air-gapped environments where the dnf fallback cannot reach cdn-ubi.redhat.com, this causes VF creation to fail silently, preventing vGPU mediated devices from being created.

Copy libpci.so* and setpci alongside lspci into the shared directory, and export LD_LIBRARY_PATH in the DTK container so the binaries can find their libraries.