### PR TITLE
Fix SELinux detection in driver scripts

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -583,7 +583,7 @@ _mount_rootfs() {
     if [ -e /sys/fs/selinux ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -580,10 +580,10 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -27,6 +27,13 @@ echo "DRIVER_ARCH is $DRIVER_ARCH"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
@@ -581,13 +588,13 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
-        echo "SELinux is enabled"
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
-        echo "SELinux is disabled, skipping..."
+        echo "Host SELinux is disabled, skipping..."
     fi
 }
 

--- a/rhel10/ocp_dtk_entrypoint
+++ b/rhel10/ocp_dtk_entrypoint
@@ -74,7 +74,7 @@ nv-ctr-run-with-dtk() {
     # Tell SELinux to allow loading these files
     find . -type f \
          \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \;
+         -exec chcon -t modules_object_t "{}" \; || true
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel10/ocp_dtk_entrypoint
+++ b/rhel10/ocp_dtk_entrypoint
@@ -72,9 +72,15 @@ nv-ctr-run-with-dtk() {
     cp -rv "${MODULES_SHARED}"/* "${MODULES_LOCAL}"
 
     # Tell SELinux to allow loading these files
-    find . -type f \
-         \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \; || true
+    echo "Check SELinux status"
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
+        echo "SELinux is enabled"
+        find . -type f \
+             \( -name "*.txt" -or -name "*.go" \) \
+             -exec chcon -t modules_object_t "{}" \;
+    else
+        echo "SELinux is disabled, skipping..."
+    fi
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel10/ocp_dtk_entrypoint
+++ b/rhel10/ocp_dtk_entrypoint
@@ -10,6 +10,13 @@ echo "Running $*"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 nv-ctr-run-with-dtk() {
     set -x
 
@@ -72,9 +79,15 @@ nv-ctr-run-with-dtk() {
     cp -rv "${MODULES_SHARED}"/* "${MODULES_LOCAL}"
 
     # Tell SELinux to allow loading these files
-    find . -type f \
-         \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \;
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
+        find . -type f \
+             \( -name "*.txt" -or -name "*.go" \) \
+             -exec chcon -t modules_object_t "{}" \;
+    else
+        echo "Host SELinux is disabled, skipping..."
+    fi
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel10/precompiled/nvidia-driver
+++ b/rhel10/precompiled/nvidia-driver
@@ -327,7 +327,7 @@ _mount_rootfs() {
     if [ -e /sys/fs/selinux ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel10/precompiled/nvidia-driver
+++ b/rhel10/precompiled/nvidia-driver
@@ -324,10 +324,10 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel10/precompiled/nvidia-driver
+++ b/rhel10/precompiled/nvidia-driver
@@ -25,6 +25,13 @@ echo "DRIVER_ARCH is $DRIVER_ARCH"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
@@ -363,13 +370,13 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
-        echo "SELinux is enabled"
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
-        echo "SELinux is disabled, skipping..."
+        echo "Host SELinux is disabled, skipping..."
     fi
 }
 

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -562,7 +562,7 @@ _mount_rootfs() {
     if [ -e /sys/fs/selinux ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -559,10 +559,10 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -26,6 +26,13 @@ echo "DRIVER_ARCH is $DRIVER_ARCH"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
@@ -558,13 +565,13 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
-        echo "SELinux is enabled"
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
-        echo "SELinux is disabled, skipping..."
+        echo "Host SELinux is disabled, skipping..."
     fi
 }
 

--- a/rhel8/ocp_dtk_entrypoint
+++ b/rhel8/ocp_dtk_entrypoint
@@ -70,7 +70,7 @@ nv-ctr-run-with-dtk() {
     # Tell SELinux to allow loading these files
     find . -type f \
          \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \;
+         -exec chcon -t modules_object_t "{}" \; || true
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel8/ocp_dtk_entrypoint
+++ b/rhel8/ocp_dtk_entrypoint
@@ -68,9 +68,15 @@ nv-ctr-run-with-dtk() {
     cp -rv "${MODULES_SHARED}"/* "${MODULES_LOCAL}"
 
     # Tell SELinux to allow loading these files
-    find . -type f \
-         \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \; || true
+    echo "Check SELinux status"
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
+        echo "SELinux is enabled"
+        find . -type f \
+             \( -name "*.txt" -or -name "*.go" \) \
+             -exec chcon -t modules_object_t "{}" \;
+    else
+        echo "SELinux is disabled, skipping..."
+    fi
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel8/ocp_dtk_entrypoint
+++ b/rhel8/ocp_dtk_entrypoint
@@ -10,6 +10,13 @@ echo "Running $*"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 nv-ctr-run-with-dtk() {
     set -x
 
@@ -68,9 +75,15 @@ nv-ctr-run-with-dtk() {
     cp -rv "${MODULES_SHARED}"/* "${MODULES_LOCAL}"
 
     # Tell SELinux to allow loading these files
-    find . -type f \
-         \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \;
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
+        find . -type f \
+             \( -name "*.txt" -or -name "*.go" \) \
+             -exec chcon -t modules_object_t "{}" \;
+    else
+        echo "Host SELinux is disabled, skipping..."
+    fi
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel8/precompiled/nvidia-driver
+++ b/rhel8/precompiled/nvidia-driver
@@ -304,7 +304,7 @@ _mount_rootfs() {
     if [ -e /sys/fs/selinux ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel8/precompiled/nvidia-driver
+++ b/rhel8/precompiled/nvidia-driver
@@ -301,10 +301,10 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel8/precompiled/nvidia-driver
+++ b/rhel8/precompiled/nvidia-driver
@@ -24,6 +24,13 @@ echo "DRIVER_ARCH is $DRIVER_ARCH"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
@@ -300,13 +307,13 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
-        echo "SELinux is enabled"
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
-        echo "SELinux is disabled, skipping..."
+        echo "Host SELinux is disabled, skipping..."
     fi
 }
 

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -576,10 +576,10 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -579,7 +579,7 @@ _mount_rootfs() {
     if [ -e /sys/fs/selinux ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -27,6 +27,13 @@ echo "DRIVER_ARCH is $DRIVER_ARCH"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
@@ -577,13 +584,13 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
-        echo "SELinux is enabled"
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
-        echo "SELinux is disabled, skipping..."
+        echo "Host SELinux is disabled, skipping..."
     fi
 }
 

--- a/rhel9/ocp_dtk_entrypoint
+++ b/rhel9/ocp_dtk_entrypoint
@@ -74,7 +74,7 @@ nv-ctr-run-with-dtk() {
     # Tell SELinux to allow loading these files
     find . -type f \
          \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \;
+         -exec chcon -t modules_object_t "{}" \; || true
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel9/ocp_dtk_entrypoint
+++ b/rhel9/ocp_dtk_entrypoint
@@ -72,9 +72,15 @@ nv-ctr-run-with-dtk() {
     cp -rv "${MODULES_SHARED}"/* "${MODULES_LOCAL}"
 
     # Tell SELinux to allow loading these files
-    find . -type f \
-         \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \; || true
+    echo "Check SELinux status"
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
+        echo "SELinux is enabled"
+        find . -type f \
+             \( -name "*.txt" -or -name "*.go" \) \
+             -exec chcon -t modules_object_t "{}" \;
+    else
+        echo "SELinux is disabled, skipping..."
+    fi
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel9/ocp_dtk_entrypoint
+++ b/rhel9/ocp_dtk_entrypoint
@@ -10,6 +10,13 @@ echo "Running $*"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 nv-ctr-run-with-dtk() {
     set -x
 
@@ -72,9 +79,15 @@ nv-ctr-run-with-dtk() {
     cp -rv "${MODULES_SHARED}"/* "${MODULES_LOCAL}"
 
     # Tell SELinux to allow loading these files
-    find . -type f \
-         \( -name "*.txt" -or -name "*.go" \) \
-         -exec chcon -t modules_object_t "{}" \;
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
+        find . -type f \
+             \( -name "*.txt" -or -name "*.go" \) \
+             -exec chcon -t modules_object_t "{}" \;
+    else
+        echo "Host SELinux is disabled, skipping..."
+    fi
 
     echo "#"
     echo "# Executing nvidia-driver load script ..."

--- a/rhel9/precompiled/nvidia-driver
+++ b/rhel9/precompiled/nvidia-driver
@@ -353,7 +353,7 @@ _mount_rootfs() {
     if [ -e /sys/fs/selinux ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel9/precompiled/nvidia-driver
+++ b/rhel9/precompiled/nvidia-driver
@@ -350,10 +350,10 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
         echo "SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
-        chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
         echo "SELinux is disabled, skipping..."
     fi

--- a/rhel9/precompiled/nvidia-driver
+++ b/rhel9/precompiled/nvidia-driver
@@ -26,6 +26,13 @@ echo "DRIVER_ARCH is $DRIVER_ARCH"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/common.sh
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 _update_package_cache() {
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         echo "Updating the package cache..."
@@ -389,13 +396,13 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Check SELinux status"
-    if [ -e /sys/fs/selinux ]; then
-        echo "SELinux is enabled"
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
         echo "Change device files security context for selinux compatibility"
         chcon -R -t container_file_t ${RUN_DIR}/driver/dev
     else
-        echo "SELinux is disabled, skipping..."
+        echo "Host SELinux is disabled, skipping..."
     fi
 }
 

--- a/vgpu-manager/rhel8/nvidia-driver
+++ b/vgpu-manager/rhel8/nvidia-driver
@@ -19,7 +19,7 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Change device files security context for selinux compatibility"
-    chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
 }
 
 # Unmount the driver rootfs from the run directory.

--- a/vgpu-manager/rhel8/nvidia-driver
+++ b/vgpu-manager/rhel8/nvidia-driver
@@ -18,8 +18,14 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Change device files security context for selinux compatibility"
-    chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+    echo "Check SELinux status"
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
+        echo "SELinux is enabled"
+        echo "Change device files security context for selinux compatibility"
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    else
+        echo "SELinux is disabled, skipping..."
+    fi
 }
 
 # Unmount the driver rootfs from the run directory.

--- a/vgpu-manager/rhel8/nvidia-driver
+++ b/vgpu-manager/rhel8/nvidia-driver
@@ -10,6 +10,13 @@ RUN_DIR=/run/nvidia
 NVIDIA_MODULE_PARAMS=()
 MODPROBE_CONFIG_DIR="/etc/modprobe.d"
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 # Mount the driver rootfs into the run directory with the exception of sysfs.
 _mount_rootfs() {
     echo "Mounting NVIDIA driver rootfs..."
@@ -18,8 +25,14 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Change device files security context for selinux compatibility"
-    chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
+        echo "Change device files security context for selinux compatibility"
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    else
+        echo "Host SELinux is disabled, skipping..."
+    fi
 }
 
 # Unmount the driver rootfs from the run directory.

--- a/vgpu-manager/rhel9/nvidia-driver
+++ b/vgpu-manager/rhel9/nvidia-driver
@@ -31,7 +31,7 @@ _mount_rootfs() {
     mount --rbind / ${RUN_DIR}/driver
 
     echo "Change device files security context for selinux compatibility"
-    chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
 }
 
 # Unmount the driver rootfs from the run directory.

--- a/vgpu-manager/rhel9/nvidia-driver
+++ b/vgpu-manager/rhel9/nvidia-driver
@@ -30,8 +30,14 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Change device files security context for selinux compatibility"
-    chcon -R -t container_file_t ${RUN_DIR}/driver/dev || true
+    echo "Check SELinux status"
+    if grep -qsw "selinuxfs" /proc/mounts && [ -f /sys/fs/selinux/enforce ]; then
+        echo "SELinux is enabled"
+        echo "Change device files security context for selinux compatibility"
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    else
+        echo "SELinux is disabled, skipping..."
+    fi
 }
 
 # Unmount the driver rootfs from the run directory.

--- a/vgpu-manager/rhel9/nvidia-driver
+++ b/vgpu-manager/rhel9/nvidia-driver
@@ -22,6 +22,13 @@ RUN_DIR=/run/nvidia
 NVIDIA_MODULE_PARAMS=()
 MODPROBE_CONFIG_DIR="/etc/modprobe.d"
 
+# Requires the pod to run with hostPID: true.
+_host_selinux_enabled() {
+    [ -r /proc/1/mounts ] &&
+        grep -qsw "selinuxfs" /proc/1/mounts &&
+        [ -f /proc/1/root/sys/fs/selinux/enforce ]
+}
+
 # Mount the driver rootfs into the run directory with the exception of sysfs.
 _mount_rootfs() {
     echo "Mounting NVIDIA driver rootfs..."
@@ -30,8 +37,14 @@ _mount_rootfs() {
     mkdir -p ${RUN_DIR}/driver
     mount --rbind / ${RUN_DIR}/driver
 
-    echo "Change device files security context for selinux compatibility"
-    chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    echo "Check host SELinux status"
+    if _host_selinux_enabled; then
+        echo "Host SELinux is enabled"
+        echo "Change device files security context for selinux compatibility"
+        chcon -R -t container_file_t ${RUN_DIR}/driver/dev
+    else
+        echo "Host SELinux is disabled, skipping..."
+    fi
 }
 
 # Unmount the driver rootfs from the run directory.


### PR DESCRIPTION
## Summary

Fix SELinux detection in the RHEL driver scripts by checking the host SELinux state instead of the container-local view.

Today the scripts use container-local `/sys/fs/selinux` checks, which can report SELinux as enabled even when it is disabled on the host. That leads the driver flow to run `chcon` in environments where host SELinux is not actually active.

This change updates the RHEL 8/9/10 driver, precompiled-driver, DTK entrypoint, and vGPU manager scripts to detect SELinux from the host by checking:

- `selinuxfs` in `/proc/1/mounts`
- `/proc/1/root/sys/fs/selinux/enforce`

When host SELinux is enabled, the existing relabeling behavior is preserved. When it is disabled, the scripts now skip the relabeling path cleanly.

## Why

The driver container needs to make decisions based on the host SELinux state, not the container filesystem view. Using the container-local check can produce false positives and trigger unnecessary or incorrect SELinux relabeling steps.

## Changes

- Add `_host_selinux_enabled()` helper in affected RHEL driver scripts
- Replace container-local SELinux detection with host SELinux detection
- Keep existing `chcon` behavior only when host SELinux is actually enabled
- Update log messages to make it explicit that the host SELinux state is being checked

## Notes

This logic expects the pod to run with `hostPID: true`, since it inspects the host view through `/proc/1/...`.

Fixes https://github.com/NVIDIA/gpu-operator/issues/1489