### PR TITLE
add CVE updates for compiled and precompiled ubuntu images

### DIFF
--- a/.github/actions/set-cve-updates/action.yml
+++ b/.github/actions/set-cve-updates/action.yml
@@ -1,0 +1,35 @@
+# Copyright NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Set CVE Updates
+description: >
+  Sets the CVE_UPDATES environment variable with the list of packages to
+  upgrade for CVE remediation, based on the target distribution family.
+inputs:
+  dist:
+    description: >
+      Target distribution string (e.g. ubuntu22.04, ubuntu24.04, rhel8,
+      rhel9, rhel10, rocky9). The action matches on the family prefix.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set CVE_UPDATES
+      shell: bash
+      run: |
+        if [[ "${{ inputs.dist }}" =~ ^(rhel|rocky) ]]; then
+          echo "CVE_UPDATES=openssl python3-urllib3 libarchive libxml2 pam python3 sqlite-libs gnupg2" >> $GITHUB_ENV
+        elif [[ "${{ inputs.dist }}" =~ ^ubuntu ]]; then
+          echo "CVE_UPDATES=gnupg2" >> $GITHUB_ENV
+        fi

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -67,13 +67,11 @@ jobs:
           fi
           echo "PUSH_ON_BUILD=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
           echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
-          
-          if [[ "${{ matrix.dist }}" =~ "rhel" || "${{ matrix.dist }}" =~ "rocky" ]]; then
-            echo "CVE_UPDATES=openssl python3-urllib3 libarchive libxml2 pam python3 sqlite-libs gnupg2" >> $GITHUB_ENV
-          elif [[ "${{ matrix.dist }}" =~ "ubuntu" ]]; then
-            echo "CVE_UPDATES=gnupg2" >> $GITHUB_ENV
-          fi
 
+      - name: Set CVE updates
+        uses: ./.github/actions/set-cve-updates
+        with:
+          dist: ${{ matrix.dist }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
@@ -157,6 +155,10 @@ jobs:
           echo "PUSH_ON_BUILD=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
           echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
 
+      - name: Set CVE updates
+        uses: ./.github/actions/set-cve-updates
+        with:
+          dist: ${{ matrix.dist }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:

--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -88,6 +88,10 @@ jobs:
           echo "PUSH_ON_BUILD=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
           echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
 
+      - name: Set CVE updates
+        uses: ./.github/actions/set-cve-updates
+        with:
+          dist: ${{ matrix.dist }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -23,9 +23,9 @@ RUN dpkg --add-architecture i386 && \
         build-essential \
         ca-certificates \
         curl \
-        gpg \
         kmod \
         file \
+        gnupg \
         libelf-dev \
         libglvnd-dev \
         pkg-config && \


### PR DESCRIPTION
Updates GitHub Actions image-build workflows to apply additional CVE-related package upgrades for Ubuntu-based images, aligning compiled and precompiled builds with a consistent set of security updates.

Changes:

Add libssl3 to Ubuntu CVE_UPDATES.
Introduce Ubuntu CVE_UPDATES export for precompiled image build jobs in both workflows.