### PR TITLE
allow specific precompiled images to be rebuilt

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -19,6 +19,28 @@ on:
   schedule:
     - cron: '00 09 * * *'
   workflow_dispatch:
+    inputs:
+      driver_branch:
+        description: 'Driver branch to build (e.g. 535). Leave empty for all.'
+        required: false
+        default: ''
+      kernel_flavor:
+        description: 'Kernel flavor to build (e.g. azure). Leave empty for all.'
+        required: false
+        default: ''
+      dist:
+        description: 'Distribution to build (e.g. ubuntu22.04). Leave empty for all.'
+        required: false
+        default: ''
+      lts_kernel:
+        description: 'LTS kernel series to build (e.g. 6.8). Leave empty for all.'
+        required: false
+        default: ''
+      force_rebuild:
+        description: 'Force rebuild and re-publish even if the image tag already exists'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: precompiled-driver-build-${{ github.ref }}
@@ -40,13 +62,38 @@ jobs:
         uses: actions/checkout@v6
       - name: Read driver versions
         id: generate_matrix_config
+        env:
+          DRIVER_BRANCH_INPUT: ${{ inputs.driver_branch }}
+          KERNEL_FLAVOR_INPUT: ${{ inputs.kernel_flavor }}
+          DIST_INPUT: ${{ inputs.dist }}
+          LTS_KERNEL_INPUT: ${{ inputs.lts_kernel }}
         run: |
           CONFIG_FILE=.github/precompiled-matrix-config.json
 
-          echo "driver_branch=$(jq -c '.driver_branch' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
-          echo "kernel_flavors=$(jq -c '.kernel_flavors' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
-          echo "dist=$(jq -c '.dist' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
-          echo "lts_kernel=$(jq -c '.lts_kernel' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
+          if [ -n "$DRIVER_BRANCH_INPUT" ]; then
+            echo "driver_branch=$(jq -cn --arg value "$DRIVER_BRANCH_INPUT" '[$value]')" >> "$GITHUB_OUTPUT"
+          else
+            echo "driver_branch=$(jq -c '.driver_branch' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$KERNEL_FLAVOR_INPUT" ]; then
+            echo "kernel_flavors=$(jq -cn --arg value "$KERNEL_FLAVOR_INPUT" '[$value]')" >> "$GITHUB_OUTPUT"
+          else
+            echo "kernel_flavors=$(jq -c '.kernel_flavors' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$DIST_INPUT" ]; then
+            echo "dist=$(jq -cn --arg value "$DIST_INPUT" '[$value]')" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist=$(jq -c '.dist' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$LTS_KERNEL_INPUT" ]; then
+            echo "lts_kernel=$(jq -cn --arg value "$LTS_KERNEL_INPUT" '[$value]')" >> "$GITHUB_OUTPUT"
+          else
+            echo "lts_kernel=$(jq -c '.lts_kernel' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
+          fi
+
           echo "exclude_build_matrix_pairs=$(jq -c '.exclude_build_matrix_pairs' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
           echo "exclude_precompiled_build_matrix=$(jq -c '.exclude_precompiled_build_matrix' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
           echo "exclude_precompiled_e2e_matrix=$(jq -c '.exclude_precompiled_e2e_matrix' "$CONFIG_FILE")" >> "$GITHUB_OUTPUT"
@@ -196,6 +243,7 @@ jobs:
           DIST: ${{ matrix.dist }}
           GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
           LTS_KERNEL: ${{ matrix.lts_kernel }}
+          FORCE_REBUILD: ${{ inputs.force_rebuild || 'false' }}
         run: |
           kernel_flavors_json='${{ needs.set-driver-version-matrix.outputs.kernel_flavors }}'
           KERNEL_FLAVORS=($(echo "$kernel_flavors_json" | jq -r '.[]'))
@@ -209,7 +257,12 @@ jobs:
             fi
           done
           source ./tests/scripts/ci-precompiled-helpers.sh
-          KERNEL_VERSIONS=($(get_kernel_versions_to_test KERNEL_FLAVORS[@] DRIVER_BRANCHES[@] $DIST $LTS_KERNEL))
+          KERNEL_VERSIONS=($(get_kernel_versions_to_test KERNEL_FLAVORS[@] DRIVER_BRANCHES[@] $DIST $LTS_KERNEL $FORCE_REBUILD))
+          rc=$?
+          if [[ $rc -ne 0 ]]; then
+            echo "registry connectivity error while determining kernel versions to test" >&2
+            exit 1
+          fi
           if [ -z "$KERNEL_VERSIONS" ]; then
             # no new kernel release
             echo "Skipping e2e tests"

--- a/scripts/precompiled.sh
+++ b/scripts/precompiled.sh
@@ -54,18 +54,36 @@ function pushBaseImage(){
     make IMAGE_NAME=${IMAGE_NAME} DRIVER_BRANCH=${DRIVER_BRANCH} KERNEL_FLAVOR=${KERNEL_FLAVOR} push-base-${BASE_TARGET}
 }
 
+function imageDigest(){
+	regctl image digest --list "$1" 2>/dev/null
+}
+
+function manifestsMatch(){
+	local src_digest
+	local dst_digest
+	src_digest=$(imageDigest "$1") || { echo "failed to get digest for $1 - assuming manifests differ"; return 1; }
+	dst_digest=$(imageDigest "$2") || { echo "failed to get digest for $2 - assuming manifests differ"; return 1; }
+	[ "$src_digest" = "$dst_digest" ]
+}
+
 function pushImage(){
 	# check if image exists in output registry
 	# note: DIST is in the form "signed_<distribution>", so we drop the '*_' prefix
 	# to extract the distribution string.
-	local out_image=${OUT_IMAGE_NAME}:${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST##*_}
+	local tag=${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST##*_}
+	local out_image=${OUT_IMAGE_NAME}:${tag}
+	local in_image=${IMAGE_NAME}:${tag}
 	if imageExists "$out_image"; then
 		echo "image tag already exists in output registry - $out_image"
 		if [ "$FORCE_PUSH" != "true" ]; then
-			echo "exiting"
-			return 0
+			if manifestsMatch "$in_image" "$out_image"; then
+				echo "source and destination manifests match - skipping push"
+				return 0
+			fi
+			echo "source and destination manifests differ - pushing updated image"
+		else
+			echo "overwriting image tag - $out_image"
 		fi
-		echo "overwriting image tag - $out_image"
 	fi
     # push the image
     make DRIVER_VERSIONS=${DRIVER_VERSIONS} DRIVER_BRANCH=${DRIVER_BRANCH} push-${DIST}

--- a/tests/scripts/ci-precompiled-helpers.sh
+++ b/tests/scripts/ci-precompiled-helpers.sh
@@ -1,6 +1,6 @@
 get_kernel_versions_to_test() {
-    if [[ "$#" -ne 4 ]]; then
-	    echo " Error:$0 must be called with KERNEL_FLAVORS DRIVER_BRANCHES DIST LTS_KERNEL" >&2
+    if [[ "$#" -lt 4 ]]; then
+	    echo " Error:$0 must be called with KERNEL_FLAVORS DRIVER_BRANCHES DIST LTS_KERNEL [FORCE_REBUILD]" >&2
 	    exit 1
     fi
 
@@ -8,11 +8,19 @@ get_kernel_versions_to_test() {
     local -a DRIVER_BRANCHES=("${!2}")
     local DIST="$3"
     local LTS_KERNEL="$4"
+    local FORCE_REBUILD="${5:-false}"
 
     kernel_versions=()
+    local had_errors=false
     for kernel_flavor in "${KERNEL_FLAVORS[@]}"; do
         for DRIVER_BRANCH in "${DRIVER_BRANCHES[@]}"; do
-            source ./tests/scripts/findkernelversion.sh "${kernel_flavor}" "$DRIVER_BRANCH" "$DIST" "$LTS_KERNEL" >&2
+            regctl_error=false
+            source ./tests/scripts/findkernelversion.sh "${kernel_flavor}" "$DRIVER_BRANCH" "$DIST" "$LTS_KERNEL" "$FORCE_REBUILD" >&2
+            if [[ "$regctl_error" == true ]]; then
+                echo "skipping ${kernel_flavor}/${DRIVER_BRANCH} due to registry connectivity error" >&2
+                had_errors=true
+                break
+            fi
             if [[ "$should_continue" == true ]]; then
                 break
             fi
@@ -28,4 +36,7 @@ get_kernel_versions_to_test() {
         kernel_versions[$i]="${kernel_versions[$i]}-$DIST"
     done
     echo "${kernel_versions[@]}"
+    if [[ "$had_errors" == true ]]; then
+        return 1
+    fi
 }

--- a/tests/scripts/findkernelversion.sh
+++ b/tests/scripts/findkernelversion.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ $# -ne 4 ]]; then
-	echo " KERNEL_FLAVOR DRIVER_BRANCH DIST LTS_KERNEL are required"
+if [[ $# -lt 4 ]]; then
+	echo " KERNEL_FLAVOR DRIVER_BRANCH DIST LTS_KERNEL [FORCE_REBUILD] are required"
 	exit 1
 fi
 
@@ -9,6 +9,7 @@ export KERNEL_FLAVOR="${1}"
 export DRIVER_BRANCH="${2}"
 export DIST="${3}"
 export LTS_KERNEL="${4}"
+FORCE_REBUILD="${5:-false}"
 
 export REGCTL_VERSION=v0.7.1
 mkdir -p bin
@@ -32,12 +33,33 @@ if [ -n "$artifact" ]; then
 fi
 
 # calculate driver tag
-status_nvcr=0
-status_ghcr=0
-regctl tag ls  nvcr.io/nvidia/driver | grep "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$" || status_nvcr=$?
-regctl tag ls  ghcr.io/nvidia/driver | grep "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$" || status_ghcr=$?
-if [[ $status_nvcr -eq 0 || $status_ghcr -eq 0 ]]; then
+nvcr_tags=$(regctl tag ls nvcr.io/nvidia/driver 2>&1)
+nvcr_status=$?
+if [[ $nvcr_status -ne 0 ]]; then
+    echo "failed to list tags from nvcr.io/nvidia/driver (exit $nvcr_status): $nvcr_tags" >&2
     export should_continue=false
-else
+    export regctl_error=true
+    return 1
+fi
+
+if echo "$nvcr_tags" | grep -q "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$"; then
+    echo "image tag ${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST} already exists on nvcr.io - rebuild not allowed" >&2
+    export should_continue=false
+elif [[ "$FORCE_REBUILD" == "true" ]]; then
+    echo "force rebuild requested for ${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}" >&2
     export should_continue=true
+else
+    ghcr_tags=$(regctl tag ls ghcr.io/nvidia/driver 2>&1)
+    ghcr_status=$?
+    if [[ $ghcr_status -ne 0 ]]; then
+        echo "failed to list tags from ghcr.io/nvidia/driver (exit $ghcr_status): $ghcr_tags" >&2
+        export should_continue=false
+        export regctl_error=true
+        return 1
+    fi
+    if echo "$ghcr_tags" | grep -q "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$"; then
+        export should_continue=false
+    else
+        export should_continue=true
+    fi
 fi


### PR DESCRIPTION
This PR adds the following capability:

Manual workflow inputs for targeted builds — each matrix dimension (driver branch, kernel flavor, dist, LTS kernel) can be filtered to a single value via workflow_dispatch inputs, instead of always building the full matrix.

Force rebuild flag — a new force_rebuild input that bypasses the ghcr.io tag-existence check (nvcr.io is still treated as authoritative). This will enable us to build and push updated images to ghcr.io which then can be published to nvcr.io