### PR TITLE
disable image push/slack notification for non main branch

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -20,6 +20,10 @@ on:
     - cron: '00 09 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: precompiled-driver-build-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   set-driver-version-matrix:
     runs-on: linux-amd64-cpu4
@@ -265,9 +269,15 @@ jobs:
             for kernel in "${LTS_KERNEL[@]}"; do
               artifact_name="matrix-values-${dist}-${kernel}"
               file_path="./matrix-values-artifacts/${artifact_name}/matrix_values_${dist}_${kernel}.json"
+              flat_path="./matrix-values-artifacts/matrix_values_${dist}_${kernel}.json"
               if [ -f "$file_path" ]; then
                 echo "Successfully found artifact: $artifact_name at $file_path"
                 value=$(jq -r '.[]' "$file_path")
+                kernel_versions+=($value)
+                echo "matrix_values_not_empty=1" >> $GITHUB_OUTPUT
+              elif [ -f "$flat_path" ]; then
+                echo "Successfully found artifact: $artifact_name at $flat_path"
+                value=$(jq -r '.[]' "$flat_path")
                 kernel_versions+=($value)
                 echo "matrix_values_not_empty=1" >> $GITHUB_OUTPUT
               else
@@ -290,7 +300,7 @@ jobs:
       # slack notification for new kernel release before e2e tests starts
       # as e2e tests may fail for new kernel release
       - name: Slack notification
-        if: steps.set_kernel_version.outputs.matrix_values_not_empty == '1'
+        if: ${{ steps.set_kernel_version.outputs.matrix_values_not_empty == '1' && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -458,7 +468,11 @@ jobs:
           image_path="./base-images-${{ matrix.driver_branch }}-${{ matrix.kernel_version }}.tar"
           echo "uploading  $image_path"
           docker load -i $image_path
-          docker push ${PRIVATE_REGISTRY}/nvidia/driver:base-${BASE_TARGET}-${LTS_KERNEL}-${KERNEL_FLAVOR}-${{ matrix.driver_branch }}
+          if [[ "${{ github.ref == 'refs/heads/main' }}" == "true" ]]; then
+            docker push ${PRIVATE_REGISTRY}/nvidia/driver:base-${BASE_TARGET}-${LTS_KERNEL}-${KERNEL_FLAVOR}-${{ matrix.driver_branch }}
+          else
+            echo "Skipping base image push for non-main branch ${{ github.ref }}"
+          fi
 
       - name: Download built image artifact
         if: ${{ ! (matrix.driver_branch == 535 && contains(matrix.kernel_version, 'ubuntu24.04')) }}
@@ -473,10 +487,14 @@ jobs:
           image_path="./driver-images-${{ matrix.driver_branch }}-${{ matrix.kernel_version }}.tar"
           echo "uploading  $image_path"
           docker load -i $image_path
-          docker push ${PRIVATE_REGISTRY}/nvidia/driver:${{ matrix.driver_branch }}-${{ matrix.kernel_version }}
+          if [[ "${{ github.ref == 'refs/heads/main' }}" == "true" ]]; then
+            docker push ${PRIVATE_REGISTRY}/nvidia/driver:${{ matrix.driver_branch }}-${{ matrix.kernel_version }}
+          else
+            echo "Skipping image push for non-main branch ${{ github.ref }}"
+          fi
 
       - name: Slack notification
-        if: ${{ ! (matrix.driver_branch == 535 && contains(matrix.kernel_version, 'ubuntu24.04')) }}
+        if: ${{ ! (matrix.driver_branch == 535 && contains(matrix.kernel_version, 'ubuntu24.04')) && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/tests/scripts/findkernelversion.sh
+++ b/tests/scripts/findkernelversion.sh
@@ -18,7 +18,7 @@ export PATH=$(pwd)/bin:${PATH}
 
 # calculate kernel version of latest image
 prefix="kernel-version-${DRIVER_BRANCH}-${LTS_KERNEL}"
-suffix="${kernel_flavor}-${DIST}"
+suffix="${KERNEL_FLAVOR}-${DIST}"
 
 artifact_dir="./kernel-version-artifacts"
 artifact=$(find "$artifact_dir" -maxdepth 1 -type d -name "${prefix}*-${suffix}" | head -1)


### PR DESCRIPTION
**Issue 1:**
 If the pipeline (`workflow_dispatch: `a manual run from a feature branch) pushes the base and driver images to the `ghcr` repo, the scheduled pipeline on main will treat that kernel version already published for base and driver image.
 As a result, it will skip e2e tests and image publish for that kernel version for main branch.

Solution:
 For manual runs via workflow_dispatch on a feature branch ( not main):
   1. disable slack notifications:  do not send slack for new-kernel or published image events.
   2. disable docker push:  do not push base or driver images to the registry.
 
 This will restrict Slack and image pushes to main (e.g. scheduled runs or manual runs from main). 
  on feature branches, only build and test, no notifications and no pushes. 
  That keeps scheduled runs on main as the only ones that publish and notify.

**issue 2:**
    file: tests/scripts/findkernelversion.sh :
    Script set `KERNEL_FLAVOR="${1}" `but used `suffix="${kernel_flavor}-${DIST}".` 
    `kernel_flavor` is never set, so `suffix` became `-${DIST}` (e.g. `-ubuntu22.04`) instead of `generic-ubuntu22.04.`
    When it works:
     Artifact dirs happen to match the wrong pattern (e.g. only one flavor, or first match ).
Solution: s`uffix="${KERNEL_FLAVOR}-${DIST}"`

**Issue 3:** 
   ```
 job: 
    Collect-e2e-test-matrix: artifact path
```

  Script expected artifact files under `./matrix-values-artifacts/${artifact_name}/matrix_values_${dist}_${kernel}.json `
 
With 

```
    download-artifact:
    merge-multiple: false
```

when only one artifact matches it is extracted flat into `./matrix-values-artifacts/ `(no `artifact-name` subdir), so the file is at `./matrix-values-artifacts/matrix_values_${dist}_${kernel}.json`.

When it works:
   Multiple matrix artifacts:  download creates one subdir per artifact.

Solution: After checking the nested path, check the flat path: `./matrix-values-artifacts/matrix_values_${dist}_${kernel}.json`, and use whichever exists so both single-artifact and multi-artifact work.

passed pipeline: 
https://github.com/NVIDIA/gpu-driver-container/actions/runs/22710560690/job/65852046464 
