### PR TITLE
bump cuda base image for precompiled ubuntu24.04

### DIFF
--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:13.1.1-base-ubuntu24.04
+FROM nvcr.io/nvidia/cuda:13.2.0-base-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -33,7 +33,7 @@ RUN dpkg --add-architecture i386 && \
 
 # Fetch GPG keys for CUDA repo
 RUN apt-key del 3bf863cc && \
-    rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/cuda* && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/3bf863cc.pub | gpg --dearmor -o /etc/apt/keyrings/cuda.pub && \
     echo "deb [signed-by=/etc/apt/keyrings/cuda.pub] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64 /" > /etc/apt/sources.list.d/cuda.list
 


### PR DESCRIPTION
This PR bumps the cuda base image used when building ubuntu24.04 precompiled image
Fixes failures seen in https://github.com/NVIDIA/gpu-driver-container/pull/655

Base image contains the correct content:
```
docker run -it nvcr.io/nvidia/cuda:13.2.0-base-ubuntu24.04 /bin/bash
root@b973177b8614:/# sha256sum /usr/share/keyrings/cuda-archive-keyring.gpg
25100d6f2eccaee7d6719a70e3c0c6145064aa9edc2c32148f693ac4c524a376  /usr/share/keyrings/cuda-archive-keyring.gpg
root@b973177b8614:/# ls /etc/apt/sources.list.d/
cuda-ubuntu2404-x86_64.list  ubuntu.sources
root@b973177b8614:/# cat /etc/apt/sources.list.d/cuda-ubuntu2404-x86_64.list
deb [signed-by=/usr/share/keyrings/cuda-archive-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/ /
root@b973177b8614:/# exit
```