### PR TITLE
bump base version used to build images for rocky9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ $(DRIVER_BUILD_TARGETS):
 build-rhcos%: SUBDIR = rhel9
 
 build-rocky9%: SUBDIR = rhel9
-build-rocky9%: DOCKER_BUILD_ARGS = --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:13.1.1-base-rockylinux9
+build-rocky9%: DOCKER_BUILD_ARGS = --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:13.2.0-base-rockylinux9
 
 build-fedora%: SUBDIR = fedora
 


### PR DESCRIPTION
This PR bumps the base image version used to build rocky9 driver images