### PR TITLE
update base image to pick any updates

### DIFF
--- a/rhel10/Dockerfile
+++ b/rhel10/Dockerfile
@@ -35,6 +35,8 @@ ENV TARGETARCH=$TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 
+RUN dnf update -y && dnf clean all
+
 #ARG BASE_URL=http://us.download.nvidia.com/XFree86/Linux-x86_64
 ARG BASE_URL=https://us.download.nvidia.com/tesla
 ARG DRIVER_VERSION
@@ -104,8 +106,8 @@ LABEL description="See summary"
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        yum update -y ${CVE_UPDATES} && \
-        rm -rf /var/cache/yum/*; \
+    dnf update -y ${CVE_UPDATES} && \
+    dnf clean all; \
     fi
 
 # Remove cuda repository to avoid GPG errors

--- a/rhel10/precompiled/Dockerfile
+++ b/rhel10/precompiled/Dockerfile
@@ -111,7 +111,8 @@ COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp
 # Kernel packages needed to build drivers / kmod
 RUN echo "${RHEL_VERSION}" > /etc/dnf/vars/releasever \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
-    && dnf -y install kmod binutils
+    && dnf -y install kmod binutils \
+    && dnf clean all
 
 # Prevent modprobe from giving a WARNING about missing files
 RUN rm -rf /lib/modules/${KERNEL_VERSION_NOARCH}.${BUILD_ARCH} \
@@ -128,6 +129,7 @@ COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/${TARGET_A
 
 # Install the Driver modules
 RUN dnf install -y /rpms/kmod-nvidia-*.rpm \
+    && dnf clean all \
     && rm -rf /rpms
 
 # Copy the rhsm-register script to enable subscription-manager during build time
@@ -162,10 +164,15 @@ RUN --mount=type=secret,id=RHSM_ORG,target=/run/secrets/RHSM_ORG \
             DRIVER_BRANCH=${versionArray[0]}; \
             dnf install -y nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_BRANCH}-${DRIVER_VERSION} ; \
         fi \
+        && dnf clean all \
         && subscription-manager unregister ; \
     fi
 
-RUN dnf clean all \
+ARG CVE_UPDATES
+RUN if [ -n "${CVE_UPDATES}" ]; then \
+        dnf update -y ${CVE_UPDATES}; \
+    fi \
+    && dnf clean all \
     && rm /usr/local/bin/rhsm-register
 
 LABEL io.k8s.display-name="NVIDIA Driver Container"

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -29,6 +29,8 @@ ENV TARGETARCH=$TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 
+RUN dnf update -y && dnf clean all
+
 #ARG BASE_URL=http://us.download.nvidia.com/XFree86/Linux-x86_64
 ARG BASE_URL=https://us.download.nvidia.com/tesla
 ARG DRIVER_VERSION
@@ -97,8 +99,8 @@ LABEL description="See summary"
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        yum update -y ${CVE_UPDATES} && \
-        rm -rf /var/cache/yum/*; \
+    dnf update -y ${CVE_UPDATES} && \
+    dnf clean all; \
     fi
 
 # Remove cuda repository to avoid GPG errors

--- a/rhel8/precompiled/Dockerfile
+++ b/rhel8/precompiled/Dockerfile
@@ -90,7 +90,8 @@ RUN echo "${RHEL_VERSION}" > /etc/dnf/vars/releasever \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
     && DRIVER_STREAM=$(echo ${DRIVER_VERSION} | cut -d '.' -f 1) \
     && dnf -y module enable nvidia-driver:${DRIVER_STREAM}/default \
-    && dnf -y install kmod binutils
+    && dnf -y install kmod binutils \
+    && dnf clean all
 
 # Prevent modprobe from giving a WARNING about missing files
 RUN rm -rf /lib/modules/${KERNEL_VERSION} \
@@ -100,7 +101,8 @@ RUN rm -rf /lib/modules/${KERNEL_VERSION} \
     && depmod ${KERNEL_VERSION}
 
 # Install the Driver modules
-RUN dnf install -y /rpms/kmod-nvidia-*.rpm
+RUN dnf install -y /rpms/kmod-nvidia-*.rpm \
+    && dnf clean all
 
 # Copy the rhsm-register script to enable subscription-manager during build time
 COPY --chmod=744 ./rhsm-register /usr/local/bin/rhsm-register
@@ -115,7 +117,8 @@ RUN --mount=type=secret,id=RHSM_ORG,target=/run/secrets/RHSM_ORG \
 	    nvidia-driver-libs-${DRIVER_VERSION} \
 	    nvidia-driver-NVML-${DRIVER_VERSION} \
         cuda-compat-${CUDA_DASHED_VERSION} \
-        cuda-cudart-${CUDA_DASHED_VERSION}
+        cuda-cudart-${CUDA_DASHED_VERSION} \
+    && dnf clean all
 
 RUN if [ "$DRIVER_TYPE" != "vgpu" ]; then \
         VERSION_ARRAY=(${DRIVER_VERSION//./ }) \
@@ -128,10 +131,15 @@ RUN if [ "$DRIVER_TYPE" != "vgpu" ]; then \
         && NSCQ_VERSION=${VERSION_ARRAY[0]}-${DRIVER_VERSION}-1 \
         && dnf install -y \
             nvidia-fabric-manager-${FABRIC_MANAGER_VERSION} \
-            libnvidia-nscq-${NSCQ_VERSION}; \
+            libnvidia-nscq-${NSCQ_VERSION} \
+        && dnf clean all; \
     fi
 
-RUN dnf clean all \
+ARG CVE_UPDATES
+RUN if [ -n "${CVE_UPDATES}" ]; then \
+        dnf update -y ${CVE_UPDATES}; \
+    fi \
+    && dnf clean all \
     && subscription-manager unregister
 
 LABEL io.k8s.display-name="NVIDIA Driver Container"

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -34,6 +34,8 @@ ENV TARGETARCH=$TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 
+RUN dnf update -y && dnf clean all
+
 #ARG BASE_URL=http://us.download.nvidia.com/XFree86/Linux-x86_64
 ARG BASE_URL=https://us.download.nvidia.com/tesla
 ARG DRIVER_VERSION
@@ -103,8 +105,8 @@ LABEL description="See summary"
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        yum update -y ${CVE_UPDATES} && \
-        rm -rf /var/cache/yum/*; \
+    dnf update -y ${CVE_UPDATES} && \
+    dnf clean all; \
     fi
 
 # Remove cuda repository to avoid GPG errors

--- a/rhel9/precompiled/Dockerfile
+++ b/rhel9/precompiled/Dockerfile
@@ -111,7 +111,8 @@ COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp
 # Kernel packages needed to build drivers / kmod
 RUN echo "${RHEL_VERSION}" > /etc/dnf/vars/releasever \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
-    && dnf -y install kmod binutils
+    && dnf -y install kmod binutils \
+    && dnf clean all
 
 # Prevent modprobe from giving a WARNING about missing files
 RUN rm -rf /lib/modules/${KERNEL_VERSION_NOARCH}.${BUILD_ARCH} \
@@ -128,6 +129,7 @@ COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/${TARGET_A
 
 # Install the Driver modules
 RUN dnf install -y /rpms/kmod-nvidia-*.rpm \
+    && dnf clean all \
     && rm -rf /rpms
 
 # Copy the rhsm-register script to enable subscription-manager during build time
@@ -162,10 +164,15 @@ RUN --mount=type=secret,id=RHSM_ORG,target=/run/secrets/RHSM_ORG \
             DRIVER_BRANCH=${versionArray[0]}; \
             dnf install -y nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_BRANCH}-${DRIVER_VERSION} ; \
         fi \
+        && dnf clean all \
         && subscription-manager unregister ; \
     fi
 
-RUN dnf clean all \
+ARG CVE_UPDATES
+RUN if [ -n "${CVE_UPDATES}" ]; then \
+        dnf update -y ${CVE_UPDATES}; \
+    fi \
+    && dnf clean all \
     && rm /usr/local/bin/rhsm-register
 
 LABEL io.k8s.display-name="NVIDIA Driver Container"

--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -28,8 +28,8 @@ LABEL description="See summary"
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        yum update -y ${CVE_UPDATES} && \
-        rm -rf /var/cache/yum/*; \
+    dnf update -y ${CVE_UPDATES} && \
+    dnf clean all; \
     fi
 
 # Add NGC DL license from the CUDA image

--- a/vgpu-manager/rhel9/Dockerfile
+++ b/vgpu-manager/rhel9/Dockerfile
@@ -41,8 +41,8 @@ LABEL description="See summary"
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES
 RUN if [ -n "${CVE_UPDATES}" ]; then \
-        yum update -y ${CVE_UPDATES} && \
-        rm -rf /var/cache/yum/*; \
+    dnf update -y ${CVE_UPDATES} && \
+    dnf clean all; \
     fi
 
 # Add NGC DL license from the CUDA image


### PR DESCRIPTION
I was seeing older version of cuda-compat-13-2 in the cuda base image we are using. Doing "dnf update" pulls in newer version and also updates few packages which had CVEs in them. Example:

```
root@rahulsharm-dev1:~# docker run -it --entrypoint /bin/bash nvcr.io/nvidia/cuda:13.2.0-base-rockylinux9
Unable to find image 'nvcr.io/nvidia/cuda:13.2.0-base-rockylinux9' locally
13.2.0-base-rockylinux9: Pulling from nvidia/cuda
812c44127102: Already exists
8200543fc3d4: Pull complete
073e9408af9e: Pull complete
f36095593a69: Pull complete
5afc9d59efc0: Pull complete
314a2f652b6c: Pull complete
Digest: sha256:909fd18005d665a0204ab8cc9b05e2e8cde00970521e6e8052c45bb6deededf9
Status: Downloaded newer image for nvcr.io/nvidia/cuda:13.2.0-base-rockylinux9
bash-5.1# dnf update -y
cuda                                                           34 MB/s | 4.2 MB     00:00
Rocky Linux 9 - BaseOS                                        6.9 MB/s |  17 MB     00:02
Rocky Linux 9 - AppStream                                     7.6 MB/s |  17 MB     00:02
Rocky Linux 9 - Extras                                        6.1 kB/s |  17 kB     00:02
Dependencies resolved.
==============================================================================================
 Package                   Architecture    Version                      Repository       Size
==============================================================================================
Upgrading:
 cuda-compat-13-2          x86_64          3:595.58.03-1.el9            cuda            100 M
 gnutls                    x86_64          3.8.3-10.el9_7               baseos          1.1 M
 libarchive                x86_64          3.5.3-7.el9_7                baseos          387 k
 python3                   x86_64          3.9.25-3.el9_7.1             baseos           26 k
 python3-libs              x86_64          3.9.25-3.el9_7.1             baseos          7.5 M
 tzdata                    noarch          2026a-1.el9_7                baseos          496 k

```

In this PR, I am running `dnf update` for base image used so that we get the base image updated as required before configuring the image further.

I also added `dnf clean all` to reduce size of intermediate layers.