### PR TITLE
[rhel10] TARGET_ARCH aarch64 instead of arm64

### DIFF
--- a/rhel10/precompiled/Dockerfile
+++ b/rhel10/precompiled/Dockerfile
@@ -159,7 +159,7 @@ RUN --mount=type=secret,id=RHSM_ORG,target=/run/secrets/RHSM_ORG \
             cuda-compat-${CUDA_DASHED_VERSION} \
             cuda-cudart-${CUDA_DASHED_VERSION} \
             nvidia-persistenced-${DRIVER_VERSION} \
-        && if [ "$DRIVER_TYPE" != "vgpu" ] && [ "$TARGETARCH" != "arm64" ]; then \
+        && if [ "$DRIVER_TYPE" != "vgpu" ] && [ "$TARGETARCH" != "aarch64" ]; then \
             versionArray=(${DRIVER_VERSION//./ }); \
             DRIVER_BRANCH=${versionArray[0]}; \
             dnf install -y nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_BRANCH}-${DRIVER_VERSION} ; \


### PR DESCRIPTION
The README documents TARGET_ARCH=aarch64 for this flow at rhel10/precompiled/README.md:

 export OPENSHIFT_VERSION='4.15.0'
  export BUILD_ARCH='aarch64+64k'
  export TARGET_ARCH=$(echo "${BUILD_ARCH}" | sed 's/+64k//')