### PR TITLE
Skip modprobe in peermem container when module is already loaded

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -922,6 +922,12 @@ reload_nvidia_peermem() {
     fi
     # get any parameters provided for nvidia-peermem
     _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -905,6 +905,12 @@ reload_nvidia_peermem() {
     fi
     # get any parameters provided for nvidia-peermem
     _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -922,6 +922,12 @@ reload_nvidia_peermem() {
     fi
     # get any parameters provided for nvidia-peermem
     _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -873,6 +873,12 @@ reload_nvidia_peermem() {
     fi
     # get any parameters provided for nvidia-peermem
     _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -756,6 +756,12 @@ reload_nvidia_peermem() {
     fi
     # get any parameters provided for nvidia-peermem
     _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"


### PR DESCRIPTION
  **Problem**                                                                                                                 
                                                                                                                          
  When a driver pod is deleted and recreated, the fast-path optimization skips kernel module compilation/installation     
  since modules are already loaded in memory. However, the peermem sidecar unconditionally runs `chroot /run/nvidia/driver 
  modprobe nvidia-peermem`, which fails because `/lib/modules/<kernel>/` has no `.ko` files on the fast path.                  
                                                            
  **Fix**

  Add an early check for /sys/module/nvidia_peermem/refcnt in reload_nvidia_peermem() before attempting modprobe. This mirrors the pattern used in nvidia-validator's `isNvidiaModuleLoaded()`.
                                                                                                                          
  **Test plan**                                                 

  - Deleted a running driver pod (kubectl delete pod <driver-pod>)                                                              
  - Verified new pod reaches Ready state with all containers running
  - Verified k8s-driver-manager logs show "skipping the uninstallation"                                                     
  - Verified nvidia-peermem-ctr logs show "already loaded, skipping modprobe"