### PR TITLE
add support for 595 branch drivers for precompiled images

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -98,7 +98,7 @@ trigger-pipeline:
 .driver-versions-precompiled-ubuntu22.04:
   parallel:
     matrix:
-      - DRIVER_BRANCH: [535, 580]
+      - DRIVER_BRANCH: [535, 580, 595]
         KERNEL_FLAVOR: [aws, azure, generic, nvidia, oracle]
         LTS_KERNEL: ["5.15", "6.8"]
 
@@ -106,7 +106,7 @@ trigger-pipeline:
 .driver-versions-precompiled-ubuntu24.04:
   parallel:
     matrix:
-      - DRIVER_BRANCH: [580]
+      - DRIVER_BRANCH: [580, 595]
         KERNEL_FLAVOR: [aws, azure, azure-fde, generic, nvidia, oracle]
         LTS_KERNEL: ["6.8"]
 

--- a/.github/precompiled-matrix-config.json
+++ b/.github/precompiled-matrix-config.json
@@ -1,5 +1,5 @@
 {
-  "driver_branch": ["535", "580"],
+  "driver_branch": ["535", "580", "595"],
   "kernel_flavors": ["aws", "azure", "azure-fde", "generic", "nvidia", "oracle"],
   "dist": ["ubuntu22.04", "ubuntu24.04"],
   "lts_kernel": ["5.15", "6.8"],

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -105,6 +105,7 @@ jobs:
         driver:
           - 535
           - 580
+          - 595
         flavor:
           - aws
           - azure

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -52,11 +52,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-utils git curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main universe" > /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main universe" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main universe" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu jammy-updates main restricted" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu jammy-security main restricted" >> /etc/apt/sources.list && \
+RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" > /etc/apt/sources.list && \
+    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     usermod -o -u 0 -g 0 _apt
 
 COPY generate-ci-config /usr/local/bin/generate-ci-config

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -38,11 +38,9 @@ RUN rm -f /etc/apt/sources.list.d/cuda* && \
     dpkg -i cuda-keyring_1.1-1_all.deb && \
     rm -f cuda-keyring_1.1-1_all.deb
 
-RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main universe" > /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main universe" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main universe" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu jammy-updates main restricted" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu jammy-security main restricted" >> /etc/apt/sources.list && \
+RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" > /etc/apt/sources.list && \
+    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     usermod -o -u 0 -g 0 _apt
 
 RUN curl -fsSL -o /usr/local/bin/donkey https://github.com/3XX0/donkey/releases/download/v1.1.0/donkey && \


### PR DESCRIPTION
Release precompiled drivers for 595 branch as well.

The Ubuntu 22.04 precompiled image needs multiverse because NVIDIA userspace packages like nvidia-utils-595-server are published there. It also needs restricted for the Canonical-signed NVIDIA kernel module packages, so both components are required for the build.