### PR TITLE
add packageRules for ubuntu22.04 and ubuntu24.04

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,32 @@
     "prHourlyLimit": 0,
     "additionalBranchPrefix": "{{packageFileDir}}-",
     "commitMessageSuffix": "[{{packageFileDir}}]",
+    "packageRules": [
+        {
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ubuntu"
+            ],
+            "matchFileNames": [
+                "ubuntu22.04/**"
+            ],
+            "allowedVersions": "/^jammy(-\\d{8})?$/"
+        },
+        {
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ubuntu"
+            ],
+            "matchFileNames": [
+                "ubuntu24.04/**"
+            ],
+            "allowedVersions": "/^noble(-\\d{8})?$/"
+        }
+    ],
     "customManagers": [
         {
             "customType": "regex",


### PR DESCRIPTION
Currently, renovate is suggesting bumps for ubuntu22.04 and ubuntu24.04 images to ubuntu26.04 as thats the latest tag which is incorrect. Adding a rule such that allowedversions match the release name(jammy/noble).