### PR TITLE
build containerized drivers for 535.309.01, 580.159.03 and 595.71.05

### DIFF
--- a/.github/actions/set-cve-updates/action.yml
+++ b/.github/actions/set-cve-updates/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.dist }}" =~ ^(rhel|rocky) ]]; then
-          echo "CVE_UPDATES=" >> $GITHUB_ENV
+          echo "CVE_UPDATES=python3 python3-libs" >> $GITHUB_ENV
         elif [[ "${{ inputs.dist }}" =~ ^ubuntu ]]; then
-          echo "CVE_UPDATES=libgnutls30 libsystemd0 libudev1" >> $GITHUB_ENV
+          echo "CVE_UPDATES=libcap2" >> $GITHUB_ENV
         fi

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         driver:
-          - 535.288.01
-          - 580.126.20
-          - 595.58.03
+          - 535.309.01
+          - 580.159.03
+          - 595.71.05
         dist:
           - ubuntu22.04
           - ubuntu24.04
@@ -42,9 +42,9 @@ jobs:
           - ${{github.event_name == 'pull_request'}}
         exclude:
           - dist: ubuntu24.04
-            driver: 535.288.01
+            driver: 535.309.01
           - dist: rhel10
-            driver: 535.288.01
+            driver: 535.309.01
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/versions.mk
+++ b/versions.mk
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # DRIVER_VERSIONS contains latest version in all active datacenter branches
-DRIVER_VERSIONS ?= 535.288.01 580.126.20 595.58.03
+DRIVER_VERSIONS ?= 535.309.01 580.159.03 595.71.05
 
-GOLANG_VERSION := 1.26.1
+GOLANG_VERSION := 1.26.2


### PR DESCRIPTION
https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-595-71-05/index.html
https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-580-159-03/index.html
https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-535-309-01/index.html

Updated list of packages to pick CVE fixes if possible.
Removed older list as those packages were already up to date.
```
#45 22.22 Building dependency tree...
#45 23.18 Reading state information...
#45 24.05 libgnutls30 is already the newest version (3.7.3-4ubuntu1.8).
#45 24.05 libsystemd0 is already the newest version (249.11-0ubuntu3.20).
#45 24.05 libudev1 is already the newest version (249.11-0ubuntu3.20).
#45 24.05 0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
```