### PR TITLE
enable detecting updates for rocky image specified in Makefile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,6 +65,17 @@
             ],
             "datasourceTemplate": "docker",
             "versioningTemplate": "ubuntu"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)Makefile$/"
+            ],
+            "matchStrings": [
+                "DOCKER_BUILD_ARGS\\s*=\\s*--build-arg\\s+BASE_IMAGE=(?<depName>\\S+):(?<currentValue>\\S+)"
+            ],
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
         }
     ]
 }


### PR DESCRIPTION
This can be tested using:
```
docker run --rm \
  --pull always \
  -v /home/user/gpu-driver-container:/tmp/repo:ro \
  -w /tmp/repo \
  -e RENOVATE_PLATFORM=local \
  -e RENOVATE_CONFIG_FILE=/tmp/repo/.github/renovate.json \
  -e RENOVATE_DRY_RUN=full \
  -e RENOVATE_LOG_LEVEL=debug \
  renovate/renovate:latest
```

Sample output:
```
{
  "packageFile": "Makefile",
  "depName": "nvcr.io/nvidia/cuda",
  "currentValue": "13.2.0-base-rockylinux9",
  "currentVersion": "13.2.0",
  "updates": [
    {
      "newVersion": "13.2.1",
      "newValue": "13.2.1-base-rockylinux9",
      "updateType": "patch",
      "branchName": "renovate/nvcr.io-nvidia-cuda-13.x"
    }
  ]
}
```