### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
     "extends": [
         "config:recommended"
     ],
+    "dependencyDashboard": false,
     "enabledManagers": [
         "dockerfile",
         "custom.regex"


### PR DESCRIPTION
Don't create unnecessary issues like https://github.com/NVIDIA/gpu-driver-container/issues/562