### PR TITLE
Fix holodeck config path in e2e workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws_ssh_key: ${{ secrets.AWS_SSH_KEY }}
-        holodeck_config: "tests/holodeck_ubuntu22.04.yaml"
+        holodeck_config: "tests/holodeck_ubuntu.yaml"
         
     - name: Get public dns name
       id: get_public_dns_name


### PR DESCRIPTION
Fix stale Holodeck config path in e2e workflow

Description:
This PR fixes the e2e-tests-nvidiadriver job failure in the End-to-end tests workflow.

Issue:
The workflow was still referencing: `tests/holodeck_ubuntu22.04.yaml`
That file no longer exists after the setholodeckvars merge, which caused the pipeline to fail with:

`error reading config file: error reading file: open /github/workspace/tests/holodeck_ubuntu22.04.yaml: no such file or directory`

Failed pipeline:
[https://github.com/NVIDIA/gpu-driver-container/actions/runs/25534851060/job/74948485470](https://github.com/NVIDIA/gpu-driver-container/actions/runs/25534851060/job/74948485470)

Fix
file `.github/workflows/ci.yaml:`

`tests/holodeck_ubuntu22.04.yaml`
to:

`tests/holodeck_ubuntu.yaml`

