### PR TITLE
avoid installing docs in image

### DIFF
--- a/rhel10/Dockerfile
+++ b/rhel10/Dockerfile
@@ -11,7 +11,7 @@ ENV DRIVER_TYPE=$DRIVER_TYPE
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf install -y git wget
+RUN dnf install -y --nodocs git wget && dnf clean all
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -10,7 +10,7 @@ ENV DRIVER_TYPE=$DRIVER_TYPE
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf install -y git wget
+RUN dnf install -y --nodocs git wget && dnf clean all
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -10,7 +10,7 @@ ENV DRIVER_TYPE=$DRIVER_TYPE
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf install -y git wget
+RUN dnf install -y --nodocs git wget && dnf clean all
 
 # download appropriate binary based on the target architecture for multi-arch builds
 RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \


### PR DESCRIPTION
Currently, git install is pulling in all the perl packages which has lot of docs in them and they have docs in them which has sample secrets. Those are flagged by CI scans and we need to get rid of them. This PR is just installing git with nodocs flag.