### PR TITLE
remove docs after running extrapkgsinstall

### DIFF
--- a/rhel10/install.sh
+++ b/rhel10/install.sh
@@ -191,6 +191,8 @@ extra_pkgs_install() {
     nvsdm_install
     nvlink5_pkgs_install
     imex_install
+    rm -rf /usr/share/doc/*
+    dnf clean all
   fi
 }
 

--- a/rhel8/install.sh
+++ b/rhel8/install.sh
@@ -158,6 +158,8 @@ extra_pkgs_install() {
       nvsdm_install
       nvlink5_pkgs_install
       imex_install
+      rm -rf /usr/share/doc/*
+      dnf clean all
   fi
 }
 

--- a/rhel9/install.sh
+++ b/rhel9/install.sh
@@ -170,6 +170,8 @@ extra_pkgs_install() {
       nvsdm_install
       nvlink5_pkgs_install
       imex_install
+      rm -rf /usr/share/doc/*
+      dnf clean all
   fi
 }
 


### PR DESCRIPTION
`sh /tmp/install.sh extrapkgsinstall` is also pulling in perl packages again and installing the docs. Adding cleanup of docs to that step.