### PR TITLE
Limit precompiled build matrix parallelism to mitigate Docker Hub 429…

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -74,6 +74,7 @@ jobs:
             dist: ubuntu24.04
           - flavor: azure-fde
             dist: ubuntu22.04
+      max-parallel: 20
     steps:
       - uses: actions/checkout@v6
         name: Check out code


### PR DESCRIPTION
**Error:** 

```
#2 [internal] load metadata for docker.io/library/ubuntu:jammy-20260410
#2 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://registry-1.docker.io/v2/library/ubuntu/manifests/sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7: 429 Too Many Requests
toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
------
 > [internal] load metadata for docker.io/library/ubuntu:jammy-20260410:
------
Dockerfile:3
--------------------
   1 |     ARG BASE_IMAGE=ubuntu:jammy-20260410
   2 |     
   3 | >>> FROM ${BASE_IMAGE}
   4 |     
   5 |     ENV DEBIAN_FRONTEND=noninteractive
--------------------
ERROR: failed to build: failed to solve: ubuntu:jammy-20260410: failed to resolve source metadata for docker.io/library/ubuntu:jammy-20260410: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://registry-1.docker.io/v2/library/ubuntu/manifests/sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7: 429 Too Many Requests
toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
make: *** [Makefile:156: build-signed_ubuntu22.04-580.126.20] Error 1
Error: Process completed with exit code 2.

```

**Issue:** 
without max-parallel: 

github can try to run nearly the whole matrix at once. On main, that can mean up to 26 concurrent jobs.
After addition of Ubuntu 26.04, that can go up to 48 concurrent jobs.

**solution**
With max-parallel: 20, only 20 matrix jobs run at a time, which reduces simultaneous docker hub pulls and helps avoid the rate-limit burst.



