### PR TITLE
make image scan job a non-blocking job

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -180,6 +180,7 @@ image-rocky10:
 # images.
 .scan-generic:
   stage: scan
+  allow_failure: true
   image: "${PULSE_IMAGE}"
   variables:
     IMAGE_NAME: "${CI_REGISTRY_IMAGE}"


### PR DESCRIPTION
This PR makes image scan job an optional requirement and doesn't block next jobs. We still make sure images are scanned and patched properly in other workflows.