### PR TITLE
Mirror Ubuntu base images to dockerhub.nvidia.com

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 24.04
-FROM ubuntu:noble-20260410 AS noble
+FROM dockerhub.nvidia.com/ubuntu:noble-20260410 AS noble
 
 SHELL ["/bin/bash", "-c"]
 
@@ -33,7 +33,7 @@ RUN chmod +x /usr/local/bin/generate-ci-config && \
 ENTRYPOINT ["/usr/bin/sleep","1000"]
 
 # Ubuntu 22.04
-FROM ubuntu:jammy-20260509 AS jammy
+FROM dockerhub.nvidia.com/ubuntu:jammy-20260509 AS jammy
 
 SHELL ["/bin/bash", "-c"]
 

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:jammy-20260509
+ARG BASE_IMAGE=dockerhub.nvidia.com/ubuntu:jammy-20260509
 
 FROM ${BASE_IMAGE} AS build
 

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:jammy-20260509
+ARG BASE_IMAGE=dockerhub.nvidia.com/ubuntu:jammy-20260509
 
 FROM ${BASE_IMAGE}
 

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:noble-20260410
+ARG BASE_IMAGE=dockerhub.nvidia.com/ubuntu:noble-20260410
 
 FROM ${BASE_IMAGE} AS build
 

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:noble-20260410
+ARG BASE_IMAGE=dockerhub.nvidia.com/ubuntu:noble-20260410
 FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
docker pull ubuntu:noble-20260410 or jammy have 100-pulls-per-6h anonymous rate limit .

Failed pipeline due to rate limit: 

[https://github.com/NVIDIA/gpu-driver-container/actions/runs/26744682802/job/78850039391](https://github.com/NVIDIA/gpu-driver-container/actions/runs/26744682802/job/78850039391)
```

#2 [internal] load metadata for docker.io/library/ubuntu:noble-20260410
#2 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://registry-1.docker.io/v2/library/ubuntu/manifests/sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b: 429 Too Many Requests
toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit

```
