### PR TITLE
fix(rhel10): Enable appstream EUS RPM repo

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -107,8 +107,10 @@ _install_prerequisites() (
     fi
 
     dnf config-manager --set-enabled rhel-10-for-$DRIVER_ARCH-baseos-eus-rpms  || true
+    dnf config-manager --set-enabled rhel-10-for-$DRIVER_ARCH-appstream-eus-rpms  || true
     if ! dnf makecache --releasever=${DNF_RELEASEVER}; then
     	dnf config-manager --set-disabled rhel-10-for-$DRIVER_ARCH-baseos-eus-rpms || true
+    	dnf config-manager --set-disabled rhel-10-for-$DRIVER_ARCH-appstream-eus-rpms || true
     fi
 
     # try with EUS disabled, if it does not work, then try just major version


### PR DESCRIPTION
Issue: https://github.com/NVIDIA/gpu-driver-container/issues/793

RHEL version :    bug                                                     resolution
10.0                     reproducible                                       patch resolves it
10.1                      both EUS repos unreachable
10.2                     reproducible                                       patch resolves it


testing method without gpu-operator installation: 

modified` /etc/yum.repos.d/redhat.repo :`
```
[rhel-10-for-x86_64-baseos-eus-rpms]
baseurl=https://cdn.redhat.com/content/eus/rhel10/$releasever/$basearch/baseos/os/
enabled=1
gpgcheck=1

[rhel-10-for-x86_64-appstream-eus-rpms]
baseurl=https://cdn.redhat.com/content/eus/rhel10/$releasever/$basearch/appstream/os/
enabled=1
gpgcheck=1
```


Reproduction
` sudo dnf --noplugins --releasever=10.0 --disablerepo='*'     --enablerepo='rhel-10-for-x86_64-baseos-eus-rpms'     repoquery --arch=x86_64 kernel-headers kernel-devel`
 output : empty

Fix
`sudo dnf --noplugins --releasever=10.0 --disablerepo='*'     --enablerepo='rhel-10-for-x86_64-baseos-eus-rpms'     --enablerepo='rhel-10-for-x86_64-appstream-eus-rpms'     repoquery --arch=x86_64 kernel-headers kernel-devel`
output : available kernel list
