### PR TITLE
[renovate][ubuntu] update allowedVersions regex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
             "matchFileNames": [
                 "ubuntu22.04/**"
             ],
-            "allowedVersions": "/^jammy(-\\d{8})?$/"
+            "allowedVersions": "/^jammy(-\\d{8}(\\.\\d+)?)?$/"
         },
         {
             "matchDatasources": [
@@ -38,7 +38,7 @@
             "matchFileNames": [
                 "ubuntu24.04/**"
             ],
-            "allowedVersions": "/^noble(-\\d{8})?$/"
+            "allowedVersions": "/^noble(-\\d{8}(\\.\\d+)?)?$/"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
~I am not sure why @renovate bot isn't creating the PRs for `ubuntu24.04`, I've decided to create this PR to bump the base images for the time beings. Even a manual trigger of the @renovate workflow didn't seem to help.~

(Updated PR as per Rahul's suggestion)

This PR should make it possible for renovate to auto-bump the ubuntu24.04 base images to the latest tag (which has a `.`) - `noble-20260509.1`