### PR TITLE
feat(vgpu-manager): ship and start Fabric Manager on NVSwitch hosts

### DIFF
--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -45,6 +45,41 @@ WORKDIR /driver
 ADD NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run .
 RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
 
+# Install NVIDIA Fabric Manager (with its NSCQ / NVSDM / NVLink Subnet Manager
+# dependencies) so the entrypoint can start it on NVSwitch (HGX) hosts. On
+# SR-IOV vGPU systems Fabric Manager must run in vGPU multitenancy mode
+# (FABRIC_MODE=2); the entrypoint writes that mode into fabricmanager.cfg before
+# starting the daemon. This mirrors how the non-vGPU driver image installs these
+# packages (see ../../ubuntu22.04/install.sh). The daemon stays dormant on
+# non-NVSwitch hosts because the entrypoint only starts it when NVSwitch devices
+# are present.
+#
+# Packages are bounded to the driver's major branch (=<branch>.*) rather than
+# pinned to the exact driver version as the non-vGPU image does: vGPU host-driver
+# patch versions are not published one-to-one as public Fabric Manager packages,
+# so an exact pin would fail to resolve. The branch bound keeps builds
+# reproducible and avoids pulling a newer-branch Fabric Manager against an older
+# driver.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    curl -fSsL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb" -o /tmp/cuda-keyring.deb && \
+    dpkg -i /tmp/cuda-keyring.deb && rm -f /tmp/cuda-keyring.deb && \
+    apt-get update && \
+    DRIVER_BRANCH="${DRIVER_VERSION%%.*}" && \
+    if [ "${DRIVER_BRANCH}" -ge 580 ]; then \
+        fm_pkg="nvidia-fabricmanager"; nscq_pkg="libnvidia-nscq"; nvsdm_pkg="libnvsdm"; \
+    else \
+        fm_pkg="nvidia-fabricmanager-${DRIVER_BRANCH}"; nscq_pkg="libnvidia-nscq-${DRIVER_BRANCH}"; nvsdm_pkg="libnvsdm-${DRIVER_BRANCH}"; \
+    fi && \
+    apt-get install -y --no-install-recommends "${fm_pkg}=${DRIVER_BRANCH}.*" "${nscq_pkg}=${DRIVER_BRANCH}.*" && \
+    apt-mark hold "${fm_pkg}" "${nscq_pkg}" && \
+    if [ "${DRIVER_BRANCH}" -ge 570 ]; then \
+        apt-get install -y --no-install-recommends "${nvsdm_pkg}=${DRIVER_BRANCH}.*" nvlsm infiniband-diags && \
+        apt-mark hold "${nvsdm_pkg}"; \
+    fi && \
+    rm -f /etc/apt/sources.list.d/cuda*.list /etc/apt/sources.list.d/cuda*.sources && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY nvidia-driver /usr/local/bin
 
 # Install / upgrade packages here that are required to resolve CVEs

--- a/vgpu-manager/ubuntu22.04/nvidia-driver
+++ b/vgpu-manager/ubuntu22.04/nvidia-driver
@@ -289,7 +289,127 @@ _unload_driver() {
     return 0
 }
 
+# Returns success if the host exposes NVSwitch devices (an HGX / NVSwitch system).
+_assert_nvswitch_system() {
+    [ -d /proc/driver/nvidia-nvswitch/devices ] || return 1
+    if [ -z "$(ls -A /proc/driver/nvidia-nvswitch/devices)" ]; then
+        return 1
+    fi
+    return 0
+}
+
+# Returns success on an NVLink5+ system (NVSwitch with an in-band NVLink Subnet
+# Manager), detected via the SW_MNG marker in an InfiniBand VPD. Mirrors the
+# non-vGPU driver image.
+_assert_nvlink5_system() (
+    for dir in /sys/class/infiniband/*/device; do
+        vpd_file="$dir/vpd"
+        if [ -f "$vpd_file" ]; then
+            if grep -q "SW_MNG" "$vpd_file"; then
+                echo "Detected NVLink5+ system"
+                return 0
+            fi
+        fi
+    done
+    return 1
+)
+
+# Wait for the NVLink5 in-band prerequisites (mlx5_core and ib_umad kernel
+# modules). Mirrors the non-vGPU driver image.
+_ensure_nvlink5_prerequisites() (
+    until lsmod | grep mlx5_core > /dev/null 2>&1 && lsmod | grep ib_umad > /dev/null 2>&1; do
+        echo "waiting for the mlx5_core and ib_umad kernel modules to be loaded"
+        sleep 10
+    done
+)
+
+# Start NVIDIA Fabric Manager on NVSwitch (HGX) hosts. On SR-IOV vGPU systems
+# Fabric Manager must run in vGPU multitenancy mode (FABRIC_MODE=2); the mode is
+# taken from the FABRIC_MODE environment variable when set, otherwise the value
+# packaged in fabricmanager.cfg is used unchanged (backward compatible). The
+# NVSwitch / NVLink5 detection and start paths mirror the non-vGPU driver image;
+# the only addition here is writing FABRIC_MODE into the config before starting.
+# This is a no-op on non-NVSwitch hosts and when Fabric Manager is not installed.
+_start_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+    local is_nvlink5=false
+
+    if _assert_nvlink5_system; then
+        is_nvlink5=true
+    elif ! _assert_nvswitch_system; then
+        return 0
+    fi
+
+    if ! type nv-fabricmanager > /dev/null 2>&1; then
+        echo "NVSwitch system detected but Fabric Manager is not installed; skipping startup"
+        return 0
+    fi
+
+    if [ -n "${FABRIC_MODE:-}" ]; then
+        # FABRIC_MODE is a small non-negative integer; validate it so a stray
+        # value cannot break the sed expression (and abort init under set -e).
+        if [[ "${FABRIC_MODE}" =~ ^[0-9]+$ ]]; then
+            echo "Setting Fabric Manager mode to FABRIC_MODE=${FABRIC_MODE} in ${fm_config_file}"
+            if grep -q '^FABRIC_MODE=' "${fm_config_file}"; then
+                sed -i "s/^FABRIC_MODE=.*/FABRIC_MODE=${FABRIC_MODE}/" "${fm_config_file}"
+            else
+                echo "FABRIC_MODE=${FABRIC_MODE}" >> "${fm_config_file}"
+            fi
+        else
+            echo "WARNING: ignoring non-numeric FABRIC_MODE='${FABRIC_MODE}'"
+        fi
+    fi
+
+    if [ "${is_nvlink5}" = true ]; then
+        _ensure_nvlink5_prerequisites || return 1
+        echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
+        local fm_pid_file=/var/run/nvidia-fabricmanager/nv-fabricmanager.pid
+        local nvlsm_config_file=/usr/share/nvidia/nvlsm/nvlsm.conf
+        local nvlsm_pid_file=/var/run/nvidia-fabricmanager/nvlsm.pid
+        /usr/bin/nvidia-fabricmanager-start.sh --mode start \
+                                               --fm-config-file "${fm_config_file}" \
+                                               --fm-pid-file "${fm_pid_file}" \
+                                               --nvlsm-config-file "${nvlsm_config_file}" \
+                                               --nvlsm-pid-file "${nvlsm_pid_file}"
+    else
+        echo "Starting NVIDIA fabric manager daemon..."
+        nv-fabricmanager -c "${fm_config_file}"
+    fi
+}
+
+# Stop NVIDIA Fabric Manager (and the NVLink Subnet Manager on NVLink5+) if
+# running. Fabric Manager holds references to the NVIDIA kernel modules, so it
+# must stop before the driver is unloaded.
+_stop_fabric_manager() {
+    local pid
+    if [ -f /var/run/nvidia-fabricmanager/nv-fabricmanager.pid ]; then
+        echo "Stopping NVIDIA fabric manager daemon..."
+        pid=$(< /var/run/nvidia-fabricmanager/nv-fabricmanager.pid)
+        kill -SIGTERM "${pid}" 2> /dev/null || true
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ "$i" -eq 50 ]; then
+            echo "Could not stop NVIDIA fabric manager daemon" >&2
+        fi
+    fi
+    if [ -f /var/run/nvidia-fabricmanager/nvlsm.pid ]; then
+        echo "Stopping NVLink Subnet Manager daemon..."
+        pid=$(< /var/run/nvidia-fabricmanager/nvlsm.pid)
+        kill -SIGTERM "${pid}" 2> /dev/null || true
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ "$i" -eq 50 ]; then
+            echo "Could not stop NVLink Subnet Manager daemon" >&2
+        fi
+    fi
+}
+
 _shutdown() {
+    _stop_fabric_manager
     if _disable_vfs && _unload_driver; then
         _unmount_rootfs
         return 0
@@ -335,6 +455,9 @@ init() {
   # Re-run nvdidia-vgpud to ensure /sys/class/mdev_bus is populated correctly. And restart nvidia-vgpu-mgr if previously killed.
   nvidia-vgpud &
   pgrep nvidia-vgpu-mgr >/dev/null || (echo "Restarting nvidia-vgpu-mgr after previously killed" && nvidia-vgpu-mgr &)
+
+  # Start NVIDIA Fabric Manager on NVSwitch (HGX) hosts. No-op on other systems.
+  _start_fabric_manager
 
   set +x
   echo "Done, now waiting for signal"

--- a/vgpu-manager/ubuntu24.04/Dockerfile
+++ b/vgpu-manager/ubuntu24.04/Dockerfile
@@ -38,6 +38,41 @@ WORKDIR /driver
 ADD NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run .
 RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
 
+# Install NVIDIA Fabric Manager (with its NSCQ / NVSDM / NVLink Subnet Manager
+# dependencies) so the entrypoint can start it on NVSwitch (HGX) hosts. On
+# SR-IOV vGPU systems Fabric Manager must run in vGPU multitenancy mode
+# (FABRIC_MODE=2); the entrypoint writes that mode into fabricmanager.cfg before
+# starting the daemon. This mirrors how the non-vGPU driver image installs these
+# packages (see ../../ubuntu24.04/install.sh). The daemon stays dormant on
+# non-NVSwitch hosts because the entrypoint only starts it when NVSwitch devices
+# are present.
+#
+# Packages are bounded to the driver's major branch (=<branch>.*) rather than
+# pinned to the exact driver version as the non-vGPU image does: vGPU host-driver
+# patch versions are not published one-to-one as public Fabric Manager packages,
+# so an exact pin would fail to resolve. The branch bound keeps builds
+# reproducible and avoids pulling a newer-branch Fabric Manager against an older
+# driver.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    curl -fSsL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb" -o /tmp/cuda-keyring.deb && \
+    dpkg -i /tmp/cuda-keyring.deb && rm -f /tmp/cuda-keyring.deb && \
+    apt-get update && \
+    DRIVER_BRANCH="${DRIVER_VERSION%%.*}" && \
+    if [ "${DRIVER_BRANCH}" -ge 580 ]; then \
+        fm_pkg="nvidia-fabricmanager"; nscq_pkg="libnvidia-nscq"; nvsdm_pkg="libnvsdm"; \
+    else \
+        fm_pkg="nvidia-fabricmanager-${DRIVER_BRANCH}"; nscq_pkg="libnvidia-nscq-${DRIVER_BRANCH}"; nvsdm_pkg="libnvsdm-${DRIVER_BRANCH}"; \
+    fi && \
+    apt-get install -y --no-install-recommends "${fm_pkg}=${DRIVER_BRANCH}.*" "${nscq_pkg}=${DRIVER_BRANCH}.*" && \
+    apt-mark hold "${fm_pkg}" "${nscq_pkg}" && \
+    if [ "${DRIVER_BRANCH}" -ge 570 ]; then \
+        apt-get install -y --no-install-recommends "${nvsdm_pkg}=${DRIVER_BRANCH}.*" nvlsm infiniband-diags && \
+        apt-mark hold "${nvsdm_pkg}"; \
+    fi && \
+    rm -f /etc/apt/sources.list.d/cuda*.list /etc/apt/sources.list.d/cuda*.sources && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY nvidia-driver /usr/local/bin
 RUN chmod +x /usr/local/bin/nvidia-driver
 

--- a/vgpu-manager/ubuntu24.04/nvidia-driver
+++ b/vgpu-manager/ubuntu24.04/nvidia-driver
@@ -289,7 +289,127 @@ _unload_driver() {
     return 0
 }
 
+# Returns success if the host exposes NVSwitch devices (an HGX / NVSwitch system).
+_assert_nvswitch_system() {
+    [ -d /proc/driver/nvidia-nvswitch/devices ] || return 1
+    if [ -z "$(ls -A /proc/driver/nvidia-nvswitch/devices)" ]; then
+        return 1
+    fi
+    return 0
+}
+
+# Returns success on an NVLink5+ system (NVSwitch with an in-band NVLink Subnet
+# Manager), detected via the SW_MNG marker in an InfiniBand VPD. Mirrors the
+# non-vGPU driver image.
+_assert_nvlink5_system() (
+    for dir in /sys/class/infiniband/*/device; do
+        vpd_file="$dir/vpd"
+        if [ -f "$vpd_file" ]; then
+            if grep -q "SW_MNG" "$vpd_file"; then
+                echo "Detected NVLink5+ system"
+                return 0
+            fi
+        fi
+    done
+    return 1
+)
+
+# Wait for the NVLink5 in-band prerequisites (mlx5_core and ib_umad kernel
+# modules). Mirrors the non-vGPU driver image.
+_ensure_nvlink5_prerequisites() (
+    until lsmod | grep mlx5_core > /dev/null 2>&1 && lsmod | grep ib_umad > /dev/null 2>&1; do
+        echo "waiting for the mlx5_core and ib_umad kernel modules to be loaded"
+        sleep 10
+    done
+)
+
+# Start NVIDIA Fabric Manager on NVSwitch (HGX) hosts. On SR-IOV vGPU systems
+# Fabric Manager must run in vGPU multitenancy mode (FABRIC_MODE=2); the mode is
+# taken from the FABRIC_MODE environment variable when set, otherwise the value
+# packaged in fabricmanager.cfg is used unchanged (backward compatible). The
+# NVSwitch / NVLink5 detection and start paths mirror the non-vGPU driver image;
+# the only addition here is writing FABRIC_MODE into the config before starting.
+# This is a no-op on non-NVSwitch hosts and when Fabric Manager is not installed.
+_start_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+    local is_nvlink5=false
+
+    if _assert_nvlink5_system; then
+        is_nvlink5=true
+    elif ! _assert_nvswitch_system; then
+        return 0
+    fi
+
+    if ! type nv-fabricmanager > /dev/null 2>&1; then
+        echo "NVSwitch system detected but Fabric Manager is not installed; skipping startup"
+        return 0
+    fi
+
+    if [ -n "${FABRIC_MODE:-}" ]; then
+        # FABRIC_MODE is a small non-negative integer; validate it so a stray
+        # value cannot break the sed expression (and abort init under set -e).
+        if [[ "${FABRIC_MODE}" =~ ^[0-9]+$ ]]; then
+            echo "Setting Fabric Manager mode to FABRIC_MODE=${FABRIC_MODE} in ${fm_config_file}"
+            if grep -q '^FABRIC_MODE=' "${fm_config_file}"; then
+                sed -i "s/^FABRIC_MODE=.*/FABRIC_MODE=${FABRIC_MODE}/" "${fm_config_file}"
+            else
+                echo "FABRIC_MODE=${FABRIC_MODE}" >> "${fm_config_file}"
+            fi
+        else
+            echo "WARNING: ignoring non-numeric FABRIC_MODE='${FABRIC_MODE}'"
+        fi
+    fi
+
+    if [ "${is_nvlink5}" = true ]; then
+        _ensure_nvlink5_prerequisites || return 1
+        echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
+        local fm_pid_file=/var/run/nvidia-fabricmanager/nv-fabricmanager.pid
+        local nvlsm_config_file=/usr/share/nvidia/nvlsm/nvlsm.conf
+        local nvlsm_pid_file=/var/run/nvidia-fabricmanager/nvlsm.pid
+        /usr/bin/nvidia-fabricmanager-start.sh --mode start \
+                                               --fm-config-file "${fm_config_file}" \
+                                               --fm-pid-file "${fm_pid_file}" \
+                                               --nvlsm-config-file "${nvlsm_config_file}" \
+                                               --nvlsm-pid-file "${nvlsm_pid_file}"
+    else
+        echo "Starting NVIDIA fabric manager daemon..."
+        nv-fabricmanager -c "${fm_config_file}"
+    fi
+}
+
+# Stop NVIDIA Fabric Manager (and the NVLink Subnet Manager on NVLink5+) if
+# running. Fabric Manager holds references to the NVIDIA kernel modules, so it
+# must stop before the driver is unloaded.
+_stop_fabric_manager() {
+    local pid
+    if [ -f /var/run/nvidia-fabricmanager/nv-fabricmanager.pid ]; then
+        echo "Stopping NVIDIA fabric manager daemon..."
+        pid=$(< /var/run/nvidia-fabricmanager/nv-fabricmanager.pid)
+        kill -SIGTERM "${pid}" 2> /dev/null || true
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ "$i" -eq 50 ]; then
+            echo "Could not stop NVIDIA fabric manager daemon" >&2
+        fi
+    fi
+    if [ -f /var/run/nvidia-fabricmanager/nvlsm.pid ]; then
+        echo "Stopping NVLink Subnet Manager daemon..."
+        pid=$(< /var/run/nvidia-fabricmanager/nvlsm.pid)
+        kill -SIGTERM "${pid}" 2> /dev/null || true
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ "$i" -eq 50 ]; then
+            echo "Could not stop NVLink Subnet Manager daemon" >&2
+        fi
+    fi
+}
+
 _shutdown() {
+    _stop_fabric_manager
     if _disable_vfs && _unload_driver; then
         _unmount_rootfs
         return 0
@@ -335,6 +455,9 @@ init() {
   # Re-run nvdidia-vgpud to ensure /sys/class/mdev_bus is populated correctly. And restart nvidia-vgpu-mgr if previously killed.
   nvidia-vgpud &
   pgrep nvidia-vgpu-mgr >/dev/null || (echo "Restarting nvidia-vgpu-mgr after previously killed" && nvidia-vgpu-mgr &)
+
+  # Start NVIDIA Fabric Manager on NVSwitch (HGX) hosts. No-op on other systems.
+  _start_fabric_manager
 
   set +x
   echo "Done, now waiting for signal"


### PR DESCRIPTION
## Description

**RFC / Draft — seeking maintainer design direction before completing. Please do not merge.**

On NVSwitch (HGX) systems running SR-IOV vGPU, NVIDIA Fabric Manager must run in vGPU multitenancy mode (`FABRIC_MODE=2`) instead of the default bare-metal / passthrough mode (`FABRIC_MODE=0`). In mode 0 a whole-card vGPU guest cannot initialize CUDA — `cuInit` fails with error 802 — because the guest's NVLink fabric never becomes usable.

Today the vGPU Manager container image ships no Fabric Manager and its entrypoint never starts it (Fabric Manager is installed only in the non-vGPU driver image, gated on `DRIVER_TYPE != vgpu`), so SR-IOV vGPU on NVSwitch cannot be brought up through this image.

This change makes the vGPU Manager image own Fabric Manager on vGPU nodes:

1. **Ship Fabric Manager.** The Ubuntu 22.04 / 24.04 vGPU Manager images install `nvidia-fabricmanager` + `libnvidia-nscq` (and, on driver branch ≥ 570, `libnvsdm` + `nvlsm` + `infiniband-diags` for the NVLink5 path) from the public CUDA repository, mirroring how the non-vGPU driver image installs them.
2. **Apply `FABRIC_MODE` and start Fabric Manager on NVSwitch hosts.** Before starting the daemon the entrypoint writes the `FABRIC_MODE` environment value into `fabricmanager.cfg` when set (validated as a non-negative integer); when unset the packaged default is left unchanged. Fabric Manager is started only when NVSwitch devices are present — using the NVLink5 start path (`nvidia-fabricmanager-start.sh` + NVLSM) on NVLink5+ systems, otherwise `nv-fabricmanager` — and is stopped before the driver is unloaded.

This is the image half of a two-repo change. The operator half — injecting `FABRIC_MODE=2` into the vGPU Manager container env on the `vm-vgpu` sandbox-workload path — is NVIDIA/gpu-operator#2602; that env is inert without this change.

### Open design questions (why this is an RFC)

- **Which component should own Fabric Manager in a vGPU-on-NVSwitch deployment?** On NVSwitch systems Fabric Manager is started today by the driver container, but in a vGPU deployment the vGPU Manager container is what runs on the node (and shipped no Fabric Manager). This PR implements the "vGPU-Manager-owns-Fabric-Manager" option to match #2602; having the driver container own it instead is also viable. I would like direction before finalizing.
- **Where should the vGPU Manager image get Fabric Manager, and at which version? (central technical risk of this RFC)** The Fabric Manager daemon is tightly version-coupled to the loaded driver — it enforces a driver-interface version check and can refuse to start against a mismatch. The non-vGPU image handles this by installing Fabric Manager from the public CUDA repository pinned to the exact driver version (`=${DRIVER_VERSION}*`), which resolves because the datacenter driver and its Fabric Manager share a version there. The vGPU Manager image is different: it must carry a Fabric Manager that matches the `vgpu-kvm` host driver baked into the image, and the public CUDA repository carries *datacenter* Fabric Manager whose patch versions do not track `vgpu-kvm` patch versions — so an exact public pin generally would not resolve. As a buildable placeholder this change installs from the public repository bounded to the driver's major branch (`=<branch>.*`), and Fabric Manager start is fatal on failure so a mismatch surfaces loudly (container restart) rather than silently. **Direct question for maintainers:** how does NVIDIA intend Fabric Manager to be packaged / sourced for the vGPU Manager image — should it come from the same source as the `vgpu-kvm` host driver (so the versions always match), rather than the public datacenter repository?
- **Should this image default `FABRIC_MODE` to 2 when the variable is unset?** No, by design here: the image is the *mechanism* (it reads `FABRIC_MODE` and applies it), and setting the mode is *policy* that belongs to the operator — #2602 injects `FABRIC_MODE=2` on the `vm-vgpu` sandbox-workload path. So an unset `FABRIC_MODE` leaves the packaged `fabricmanager.cfg` default unchanged, which keeps the image a faithful consumer, avoids double-defaulting with the operator, and leaves existing non-multitenancy vGPU deployments unaffected on upgrade. Hardcoding mode 2 in the image would break that backward compatibility for standalone use and duplicate the operator's policy.
- **Distro coverage.** Implemented for the Ubuntu images. The RHEL vGPU Manager images can follow the same pattern (dnf) once the approach is agreed.

Out of scope: the host-installed-driver path (`driver.enabled=false`), and per-VM fabric-partition activation (a device-plugin concern).

Related: NVIDIA/gpu-operator#2602 (operator half), NVIDIA/gpu-operator#2594 (adjacent SR-IOV / vendor-specific VFIO vGPU device-creation gap on the same class of hardware).

## Testing

- `shellcheck` on the changed entrypoints and `hadolint` on the changed Dockerfiles introduce no new findings versus the base branch.
- The entrypoint logic was exercised in isolation with stubs: non-NVSwitch host is a no-op; NVSwitch host without Fabric Manager installed skips with a message; `FABRIC_MODE=2` rewrites an existing `FABRIC_MODE=0`; unset `FABRIC_MODE` leaves the config untouched; a non-numeric `FABRIC_MODE` is rejected with a warning; and a stale or empty Fabric Manager pid file no longer aborts driver teardown on shutdown.
- A full `docker build` of the vGPU Manager image was not run: it requires the proprietary `NVIDIA-Linux-<arch>-<version>-vgpu-kvm.run` host-driver installer in the build context, which is not publicly downloadable. End-to-end behavior on NVSwitch hardware depends on the companion operator change and cannot run in CI here.
