### PR TITLE
Add Ubuntu 26.04 driver container with package-based driver install

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -89,6 +89,11 @@ trigger-pipeline:
     matrix:
       - DRIVER_VERSION: [580.173.02, 595.71.05]
 
+.driver-versions-ubuntu26.04:
+  parallel:
+    matrix:
+      - DRIVER_VERSION: [595.71.05]
+
 .driver-versions-rhel10:
   parallel:
     matrix:
@@ -126,6 +131,10 @@ trigger-pipeline:
 .dist-ubuntu24.04:
   variables:
     DIST: ubuntu24.04
+
+.dist-ubuntu26.04:
+  variables:
+    DIST: ubuntu26.04
 
 .dist-rhel8:
   variables:
@@ -223,6 +232,13 @@ trigger-pipeline:
   rules:
     - if: $CI_PIPELINE_SOURCE != "schedule" && $CI_COMMIT_TAG == null
 
+.release-ubuntu26.04:
+  extends:
+    - .release-generic
+    - .driver-versions-ubuntu26.04
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "schedule" && $CI_COMMIT_TAG == null
+
 .release-rhel9:
   # Perform for each DRIVER_VERSION
   extends:
@@ -295,6 +311,15 @@ trigger-pipeline:
 .release:staging-ubuntu24.04:
   extends:
     - .release-ubuntu24.04
+  variables:
+    OUT_REGISTRY_USER: "${NGC_REGISTRY_USER}"
+    OUT_REGISTRY_TOKEN: "${NGC_REGISTRY_TOKEN}"
+    OUT_REGISTRY: "${NGC_REGISTRY}"
+    OUT_IMAGE_NAME: "${NGC_STAGING_REGISTRY}/driver"
+
+.release:staging-ubuntu26.04:
+  extends:
+    - .release-ubuntu26.04
   variables:
     OUT_REGISTRY_USER: "${NGC_REGISTRY_USER}"
     OUT_REGISTRY_TOKEN: "${NGC_REGISTRY_TOKEN}"
@@ -390,6 +415,13 @@ release:staging-ubuntu24.04:
     - .dist-ubuntu24.04
   needs:
     - image-ubuntu24.04
+
+release:staging-ubuntu26.04:
+  extends:
+    - .release:staging-ubuntu26.04
+    - .dist-ubuntu26.04
+  needs:
+    - image-ubuntu26.04
 
 release:staging-rhel8:
   extends:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -33,6 +33,7 @@ jobs:
         dist:
           - ubuntu22.04
           - ubuntu24.04
+          - ubuntu26.04
           - rhel8
           - rhel9
           - rhel10
@@ -41,6 +42,9 @@ jobs:
           - rocky10
         ispr:
           - ${{github.event_name == 'pull_request'}}
+        exclude:
+          - dist: ubuntu26.04
+            driver: 580.173.02
       fail-fast: false
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -72,7 +72,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
-          image: tonistiigi/binfmt:qemu-v6.2.0
+          # The Ubuntu 26.04 arm64 userland needs a newer emulator than the qemu-v6.2.0
+          # used for every other distribution: v6.2.0 hangs on it, and on the
+          # resolute-20260707 userland v8.1.5 fails with ENOSYS and v9.2.2 with EINVAL
+          # (tar file extraction), so it is pinned to qemu-v10.1.3.
+          image: tonistiigi/binfmt:${{ matrix.dist == 'ubuntu26.04' && 'qemu-v10.1.3' || 'qemu-v6.2.0' }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
@@ -155,7 +159,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
-          image: tonistiigi/binfmt:qemu-v6.2.0
+          # The Ubuntu 26.04 arm64 userland needs a newer emulator than the qemu-v6.2.0
+          # used for every other distribution: v6.2.0 hangs on it, and on the
+          # resolute-20260707 userland v8.1.5 fails with ENOSYS and v9.2.2 with EINVAL
+          # (tar file extraction), so it is pinned to qemu-v10.1.3.
+          image: tonistiigi/binfmt:${{ matrix.dist == 'ubuntu26.04' && 'qemu-v10.1.3' || 'qemu-v6.2.0' }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,14 @@ include:
     - if: $CI_PIPELINE_SOURCE != "schedule"
 
 # Define the image build targets
+.image-build-ubuntu26.04:
+  extends:
+    - .driver-versions-ubuntu26.04
+    - .image-build-generic
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "schedule"
+
+# Define the image build targets
 .image-build-rhel9:
   # Perform for each DRIVER_VERSION
   extends:
@@ -85,6 +93,11 @@ image-ubuntu24.04:
   extends:
     - .image-build-ubuntu24.04
     - .dist-ubuntu24.04
+
+image-ubuntu26.04:
+  extends:
+    - .image-build-ubuntu26.04
+    - .dist-ubuntu26.04
 
 image-rhel8:
   extends:

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -88,6 +88,15 @@ variables:
       when: never
     - !reference [.image-pull-rules, rules]
 
+.image-pull-ubuntu26.04:
+  extends:
+    - .driver-versions-ubuntu26.04
+    - .image-pull-generic
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - !reference [.image-pull-rules, rules]
+
 .image-pull-rhel10:
   # Perform for each DRIVER_VERSION
   extends:
@@ -158,6 +167,11 @@ image-ubuntu24.04:
   extends:
     - .image-pull-ubuntu24.04
     - .dist-ubuntu24.04
+
+image-ubuntu26.04:
+  extends:
+    - .image-pull-ubuntu26.04
+    - .dist-ubuntu26.04
 
 image-rhel8:
   extends:
@@ -271,6 +285,17 @@ image-rocky10:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - !reference [.pipeline-trigger-rules, rules]
 
+.scan-ubuntu26.04:
+  extends:
+    - .driver-versions-ubuntu26.04
+    - .scan-generic
+  rules:
+    - !reference [.scan-rules-common, rules]
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - !reference [.pipeline-trigger-rules, rules]
+
 .scan-rhel10:
   # Repeat for each DRIVER_VERSION
   extends:
@@ -350,6 +375,22 @@ scan-ubuntu24.04-arm64:
     - .platform-arm64
   needs:
     - image-ubuntu24.04
+
+scan-ubuntu26.04-amd64:
+  extends:
+    - .scan-ubuntu26.04
+    - .dist-ubuntu26.04
+    - .platform-amd64
+  needs:
+    - image-ubuntu26.04
+
+scan-ubuntu26.04-arm64:
+  extends:
+    - .scan-ubuntu26.04
+    - .dist-ubuntu26.04
+    - .platform-arm64
+  needs:
+    - image-ubuntu26.04
 
 scan-precompiled-ubuntu24.04-amd64:
   variables:
@@ -507,6 +548,12 @@ release:ngc-ubuntu24.04:
     - .release:ngc
     - .dist-ubuntu24.04
     - .driver-versions-ubuntu24.04
+
+release:ngc-ubuntu26.04:
+  extends:
+    - .release:ngc
+    - .dist-ubuntu26.04
+    - .driver-versions-ubuntu26.04
 
 release:ngc-precompiled-ubuntu24.04:
   variables:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OUT_IMAGE_TAG = $(OUT_IMAGE_VERSION)-$(OUT_DIST)
 OUT_IMAGE = $(OUT_IMAGE_NAME):$(OUT_IMAGE_TAG)
 
 ##### Public rules #####
-DISTRIBUTIONS := ubuntu22.04 ubuntu24.04 signed_ubuntu22.04 signed_ubuntu24.04 signed_ubuntu26.04 rhel8 rhel9 rhel10 rocky8 rocky9 rocky10 precompiled_rhcos
+DISTRIBUTIONS := ubuntu22.04 ubuntu24.04 ubuntu26.04 signed_ubuntu22.04 signed_ubuntu24.04 signed_ubuntu26.04 rhel8 rhel9 rhel10 rocky8 rocky9 rocky10 precompiled_rhcos
 RHCOS_VERSIONS := rhcos4.14 rhcos4.15 rhcos4.16 rhcos4.17 rhcos4.18 rhel9.6
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))
 BASE_FROM := resolute noble jammy

--- a/ubuntu26.04/Dockerfile
+++ b/ubuntu26.04/Dockerfile
@@ -1,0 +1,100 @@
+ARG BASE_IMAGE=ubuntu:resolute-20260707
+
+FROM ${BASE_IMAGE} AS build
+
+ARG TARGETARCH
+ARG GOLANG_VERSION
+
+# Arg to indicate if driver type is either of passthrough(baremetal) or vgpu
+ARG DRIVER_TYPE=passthrough
+ENV DRIVER_TYPE=$DRIVER_TYPE
+
+SHELL ["/bin/bash", "-c"]
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        apt-utils \
+        build-essential \
+        ca-certificates \
+        curl \
+        git  \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# download appropriate binary based on the target architecture for multi-arch builds
+RUN OS_ARCH=${TARGETARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    | tar -C /usr/local -xz
+
+ENV PATH=/usr/local/go/bin:$PATH
+
+WORKDIR /work
+
+RUN if [ "$DRIVER_TYPE" = "vgpu" ]; then \
+    git clone https://github.com/NVIDIA/gpu-driver-container driver && \
+    cd driver/vgpu/src && \
+    go build -o vgpu-util && \
+    mv vgpu-util /work; fi
+
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-c"]
+
+ARG TARGETARCH
+ENV TARGETARCH=$TARGETARCH
+ARG DRIVER_VERSION
+ARG GIT_COMMIT
+ENV DRIVER_VERSION=$DRIVER_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Arg to indicate if driver type is either of passthrough(baremetal) or vgpu
+ARG DRIVER_TYPE=passthrough
+ENV DRIVER_TYPE=$DRIVER_TYPE
+ARG DRIVER_BRANCH=595
+ENV DRIVER_BRANCH=$DRIVER_BRANCH
+ARG VGPU_LICENSE_SERVER_TYPE=NLS
+ENV VGPU_LICENSE_SERVER_TYPE=$VGPU_LICENSE_SERVER_TYPE
+# Enable vGPU version compability check by default
+ARG DISABLE_VGPU_VERSION_CHECK=true
+ENV DISABLE_VGPU_VERSION_CHECK=$DISABLE_VGPU_VERSION_CHECK
+ENV NVIDIA_VISIBLE_DEVICES=void
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN echo "TARGETARCH=$TARGETARCH"
+
+ADD install.sh /tmp
+
+RUN usermod -o -u 0 -g 0 _apt && \
+    /tmp/install.sh depinstall
+
+# Install the driver payload for passthrough/baremetal types; the vgpu type installs from a
+# .run file at container start
+RUN /tmp/install.sh driver_pkgs_install
+
+COPY nvidia-driver /usr/local/bin
+
+COPY --from=build /work/vgpu-util* /usr/local/bin
+
+ADD drivers drivers/
+
+WORKDIR  /drivers
+
+# Install / upgrade packages here that are required to resolve CVEs
+ARG CVE_UPDATES
+RUN if [ -n "${CVE_UPDATES}" ]; then \
+        apt-get update && apt-get --only-upgrade -y install ${CVE_UPDATES} && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+LABEL io.k8s.display-name="NVIDIA Driver Container"
+LABEL name="NVIDIA Driver Container"
+LABEL vendor="NVIDIA"
+LABEL version="${DRIVER_VERSION}"
+LABEL vcs-ref="${GIT_COMMIT}"
+LABEL release="N/A"
+LABEL summary="Provision the NVIDIA driver through containers"
+LABEL description="See summary"
+
+ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu26.04/README.md
+++ b/ubuntu26.04/README.md
@@ -1,0 +1,19 @@
+# Ubuntu 26.04
+
+Driver container for Ubuntu 26.04.
+
+For the passthrough/baremetal driver type, the NVIDIA driver is installed from the NVIDIA CUDA
+APT repository (`ubuntu2604`) instead of the `.run` installer:
+
+- At image build, the version-specific `nvidia-driver-pinning-<version>` package pins the whole
+  driver tree to `DRIVER_VERSION`, the full driver userspace is preinstalled into the image, and
+  the kernel module packages are baked into a local `file:` APT repo. The CUDA network repository
+  is then removed from the APT sources.
+- At container start, the kernel headers for the running kernel are installed, then the driver
+  metapackage (`nvidia-open` for `KERNEL_MODULE_TYPE=open`/`auto`, `cuda-drivers` for
+  `proprietary`) is installed from the local repo and DKMS builds the kernel modules. Network
+  access is needed only for the kernel headers.
+
+The vGPU driver type continues to install from a user-supplied `.run` file placed in `drivers/`.
+
+See https://github.com/NVIDIA/nvidia-docker/wiki/Driver-containers-(Beta)

--- a/ubuntu26.04/drivers/README.md
+++ b/ubuntu26.04/drivers/README.md
@@ -1,0 +1,1 @@
+# Folder for downloading vGPU drivers and dependent metadata files

--- a/ubuntu26.04/install.sh
+++ b/ubuntu26.04/install.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -eu
+
+LOCAL_REPO_DIR=/usr/local/repos
+
+dep_install () {
+    if [ "$TARGETARCH" = "amd64" ]; then
+        dpkg --add-architecture i386 && \
+            apt-get update && apt-get install -y --no-install-recommends \
+            apt-utils \
+            build-essential \
+            ca-certificates \
+            curl \
+            kmod \
+            file \
+            gnupg \
+            libelf-dev \
+            libglvnd-dev \
+            pkg-config && \
+        rm -rf /var/lib/apt/lists/*
+    elif [ "$TARGETARCH" = "arm64" ]; then
+        dpkg --add-architecture arm64 && \
+            apt-get update && apt-get install -y \
+            build-essential \
+            ca-certificates \
+            curl \
+            kmod \
+            file \
+            gnupg \
+            libelf-dev \
+            libglvnd-dev && \
+        rm -rf /var/lib/apt/lists/*
+    fi
+}
+
+setup_cuda_repo() {
+    # Fetch public CUDA GPG key and configure apt to only use this key when downloading CUDA packages
+    OS_ARCH=${TARGETARCH/amd64/x86_64} && OS_ARCH=${OS_ARCH/arm64/sbsa};
+    curl -fSsL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/${OS_ARCH}/cuda-keyring_1.1-1_all.deb" -o cuda-keyring_1.1-1_all.deb
+    dpkg -i cuda-keyring_1.1-1_all.deb
+    rm -f cuda-keyring_1.1-1_all.deb
+}
+
+# Pin the driver metapackage and the extra packages to the exact DRIVER_VERSION release.
+pin_driver_version() {
+    apt-get update
+    apt-get install -y --no-install-recommends nvidia-driver-pinning-${DRIVER_VERSION}
+}
+
+# Preinstall the driver userspace: nvidia-headless-no-dkms-open plus the display/codec libraries
+# it omits. nvidia-dkms[-open] is left out and installed at container start, so no kernel module
+# is registered or built at image build time. zstd is used by dkms to compress built modules
+# (kernel modules are zstd-compressed on 26.04) but is not one of its dependencies.
+userspace_install() {
+    apt-get install -y --no-install-recommends \
+        nvidia-headless-no-dkms-open \
+        libnvidia-gl \
+        libnvidia-decode \
+        libnvidia-encode \
+        libnvidia-fbc1 \
+        libnvidia-extra \
+        dkms \
+        zstd
+}
+
+extra_pkgs_install() {
+    # The pinning package constrains the driver-versioned packages (fabricmanager, nscq, imex)
+    # to DRIVER_VERSION; nvlsm and infiniband-diags are versioned independently of the driver.
+    apt-get install -y --no-install-recommends \
+        nvidia-fabricmanager \
+        libnvidia-nscq \
+        nvidia-imex \
+        nvlsm \
+        infiniband-diags
+
+    # libnvsdm packages are not available for arm64
+    if [ "$TARGETARCH" = "amd64" ]; then
+        apt-get install -y --no-install-recommends libnvsdm
+    fi
+}
+
+# Download the kernel module packages and metapackage shims into a local file: apt repo, then
+# remove the CUDA network source so NVIDIA packages resolve only from the local repo at
+# container start. Must run last: the preceding install steps need the CUDA network source.
+build_module_repo() {
+    mkdir -p ${LOCAL_REPO_DIR}
+    cd ${LOCAL_REPO_DIR}
+    # nvidia-firmware is already installed at build, but the GPU operator mounts a host
+    # directory over /lib/firmware at runtime, which hides the installed files. The runtime
+    # reinstalls the package from this repo so the files are written into that host directory.
+    apt-get download nvidia-dkms-open nvidia-open nvidia-driver-open \
+                     nvidia-dkms nvidia-kernel-source nvidia-driver cuda-drivers \
+                     nvidia-firmware
+    dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+    echo "deb [trusted=yes] file:${LOCAL_REPO_DIR} ./" > /etc/apt/sources.list.d/local-nvidia.list
+    rm -f /etc/apt/sources.list.d/cuda*
+    rm -rf /var/lib/apt/lists/*
+}
+
+# Install the driver payload for the passthrough/baremetal type. The vgpu type installs from a
+# user-supplied .run file at container start, so all package setup is skipped.
+driver_pkgs_install() {
+    if [ "$DRIVER_TYPE" = "vgpu" ]; then
+        echo "Skipping driver package install for the vgpu driver type"
+        return 0
+    fi
+    setup_cuda_repo
+    pin_driver_version
+    userspace_install
+    extra_pkgs_install
+    build_module_repo
+}
+
+if [ "$1" = "depinstall" ]; then
+  dep_install
+elif [ "$1" = "driver_pkgs_install" ]; then
+  driver_pkgs_install
+else
+  echo "Unknown function: $1"
+  exit 1
+fi

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,0 +1,937 @@
+#! /bin/bash
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+
+set -eu
+
+RUN_DIR=/run/nvidia
+PID_FILE=${RUN_DIR}/${0##*/}.pid
+DRIVER_VERSION=${DRIVER_VERSION:?"Missing DRIVER_VERSION env"}
+KERNEL_UPDATE_HOOK=/run/kernel/postinst.d/update-nvidia-driver
+NUM_VGPU_DEVICES=0
+GPU_DIRECT_RDMA_ENABLED="${GPU_DIRECT_RDMA_ENABLED:-false}"
+USE_HOST_MOFED="${USE_HOST_MOFED:-false}"
+NVIDIA_MODULE_PARAMS=()
+NVIDIA_UVM_MODULE_PARAMS=()
+NVIDIA_MODESET_MODULE_PARAMS=()
+NVIDIA_PEERMEM_MODULE_PARAMS=()
+TARGETARCH=${TARGETARCH:?"Missing TARGETARCH env"}
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE:-auto}
+UBUNTU_PRO_TOKEN=${UBUNTU_PRO_TOKEN:-""}
+MODPROBE_CONFIG_DIR="/etc/modprobe.d"
+LOCAL_REPO_SOURCE_LIST="sources.list.d/local-nvidia.list"
+
+export DEBIAN_FRONTEND=noninteractive
+
+DRIVER_ARCH=${TARGETARCH/amd64/x86_64} && DRIVER_ARCH=${DRIVER_ARCH/arm64/aarch64}
+
+echo "DRIVER_ARCH is $DRIVER_ARCH"
+
+_enable_fips_if_required() {
+    if [[ -n "${UBUNTU_PRO_TOKEN}" && ${KERNEL_VERSION} =~ "fips" ]]; then
+      echo "Ubuntu Pro token and FIPS kernel detected"
+      apt-get install -y --no-install-recommends ubuntu-advantage-tools
+
+      # This workaround is needed in Ubuntu 24.04 as OpenSSL attempts to leverage the FIPS provider
+      # when the underlying kernel is FIPS enabled.
+      export OPENSSL_FORCE_FIPS_MODE=0
+
+      echo "Attaching Ubuntu Pro token..."
+      pro attach --no-auto-enable "${UBUNTU_PRO_TOKEN}"
+      echo "Enabling FIPS apt repo access..."
+      pro enable --access-only --assume-yes fips-updates
+      echo "Installing the OpenSSL FIPS modules"
+      apt-get install -y --no-install-recommends ubuntu-fips-userspace
+
+      # With the OpenSSL FIPS module installed, OpenSSL can now work with the default settings,
+      unset OPENSSL_FORCE_FIPS_MODE
+    fi
+}
+
+_update_package_cache() {
+    if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
+        echo "Updating the package cache..."
+        if ! apt-get -qq update; then
+            echo "ERROR: Failed to update package cache. "\
+                 "Ensure that the cluster can access the proper networks."
+            exit 1
+        fi
+    fi
+}
+
+_cleanup_package_cache() {
+    if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
+        echo "Cleaning up the package cache..."
+        rm -rf /var/lib/apt/lists/*
+    fi
+}
+
+# Refresh the package list for the local file: repo baked into the image. Reads only from the
+# image filesystem (no network access) and leaves the lists of all other sources in place.
+_update_local_repo_lists() {
+    apt-get update \
+        -o Dir::Etc::sourcelist="${LOCAL_REPO_SOURCE_LIST}" \
+        -o Dir::Etc::sourceparts="-" \
+        -o APT::Get::List-Cleanup="0"
+}
+
+_update_ca_certificates() {
+    if [ ! -z "$(ls -A /usr/local/share/ca-certificates)" ]; then
+        update-ca-certificates
+    fi
+}
+
+# Resolve the kernel version to the form major.minor.patch-revision-flavor where flavor defaults to generic.
+_resolve_kernel_version() {
+    echo "Resolving Linux kernel version..."
+
+    local version_info=$(apt-cache show "linux-headers-${KERNEL_VERSION}" 2> /dev/null || true)
+    if [ -z "${version_info}" ]; then
+        echo "Could not resolve Linux kernel version" >&2
+        return 1
+    fi
+
+    local version=$(printf "%s\n" "${version_info}" | \
+      sed -nE 's/^Version:\s+(([0-9]+\.){2}[0-9]+)[-.]([0-9]+)\..*/\1-\3/p' | head -1)
+
+    if [ -z "${version}" ]; then
+        # Custom/non-standard kernel: keep KERNEL_VERSION unchanged.
+        echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+        return 0
+    fi
+
+    local kernel_flavor=$(echo "${KERNEL_VERSION}" | sed 's/[^a-z]*//')
+    kernel_flavor="${kernel_flavor//virtual/generic}"
+
+    KERNEL_VERSION="${version}-${kernel_flavor}"
+    echo "Proceeding with Linux kernel version ${KERNEL_VERSION}"
+    return 0
+}
+
+# Install the kernel modules header/builtin/order files and generate the kernel version string.
+_install_prerequisites() (
+    local tmp_dir=$(mktemp -d)
+
+    trap "rm -rf ${tmp_dir}" EXIT
+    cd ${tmp_dir}
+
+    rm -rf /lib/modules/${KERNEL_VERSION}
+    mkdir -p /lib/modules/${KERNEL_VERSION}/proc
+
+    echo "Installing Linux kernel headers..."
+    apt-get install -y --no-install-recommends linux-headers-${KERNEL_VERSION}
+
+    echo "Installing Linux kernel module files..."
+    apt-get download linux-image-${KERNEL_VERSION} && dpkg -x linux-image*.deb .
+    { apt-get download linux-modules-${KERNEL_VERSION} && dpkg -x linux-modules*.deb . || true; }
+    # Ubuntu 26.04 kernel debs ship their payload under usr/lib/modules (merged-usr paths),
+    # unlike the lib/modules payload on 24.04 and earlier.
+    mv usr/lib/modules/${KERNEL_VERSION}/modules.* /lib/modules/${KERNEL_VERSION}
+    mv usr/lib/modules/${KERNEL_VERSION}/kernel /lib/modules/${KERNEL_VERSION}
+    depmod ${KERNEL_VERSION}
+
+    echo "Generating Linux kernel version string..."
+
+    ls -1 boot/vmlinuz-* | sed  's/\/boot\/vmlinuz-//g' - > version
+    if [ -z "$(<version)" ]; then
+        echo "Could not locate Linux kernel version string" >&2
+        return 1
+    fi
+    mv version /lib/modules/${KERNEL_VERSION}/proc
+)
+
+# Cleanup the prerequisites installed above.
+_remove_prerequisites() {
+    if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
+        apt-get purge -y linux-headers-${KERNEL_VERSION}
+        # TODO remove module files not matching an existing driver package.
+    fi
+}
+
+# This is required as currently GPU driver installer doesn't expect headers in x86_64 folder, but only in either default
+# or kernel-version folder.
+_link_ofa_kernel() (
+    if _gpu_direct_rdma_enabled; then
+        ln -s /run/mellanox/drivers/usr/src/ofa_kernel /usr/src/
+        # if arch directory exists(MOFED >=5.5) then create a symlink as expected by GPU driver installer
+        # ls -ltr /usr/src/ofa_kernel/
+        # lrwxrwxrwx 1 root root   36 Dec  8 20:10 default -> /etc/alternatives/ofa_kernel_headers
+        # drwxr-xr-x 4 root root 4096 Dec  8 20:14 x86_64
+        # lrwxrwxrwx 1 root root   44 Dec  9 19:05 5.4.0-90-generic -> /usr/src/ofa_kernel/x86_64/5.4.0-90-generic/
+        if [[ -d /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/$(uname -r) ]]; then
+            if [[ ! -e /usr/src/ofa_kernel/$(uname -r) ]]; then
+                ln -s /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/$(uname -r) /usr/src/ofa_kernel/
+            fi
+        fi
+    fi
+)
+
+_assert_nvswitch_system() {
+    [ -d /proc/driver/nvidia-nvswitch/devices ] || return 1
+    if [ -z "$(ls -A /proc/driver/nvidia-nvswitch/devices)" ]; then
+        return 1
+    fi
+    return 0
+}
+
+_assert_nvlink5_system() (
+    for dir in /sys/class/infiniband/*/device; do
+        # Define the path to the VPD file
+        vpd_file="$dir/vpd"
+
+        # Check if the VPD file exists
+        if [ -f "$vpd_file" ]; then
+            # Search for 'SW_MNG' in the VPD file
+            if grep -q "SW_MNG" "$vpd_file"; then
+                echo "Detected NVLink5+ system"
+                return 0
+            fi
+        fi
+    done
+    return 1
+)
+
+_ensure_nvlink5_prerequisites() (
+    until  lsmod | grep mlx5_core > /dev/null 2>&1 && lsmod | grep ib_umad > /dev/null 2>&1;
+    do
+        echo "waiting for the mlx5_core and ib_umad kernel modules to be loaded"
+        sleep 10
+    done
+)
+
+# Check if mellanox devices are present
+_mellanox_devices_present() {
+    devices_found=0
+    for dev in /sys/bus/pci/devices/*; do
+        read vendor < $dev/vendor
+        if [ "$vendor" = "0x15b3" ]; then
+            echo "Mellanox device found at $(basename $dev)"
+            return 0
+        fi
+    done
+    echo "No Mellanox devices were found..."
+    return 1
+}
+
+_gpu_direct_rdma_enabled() {
+    if [ "${GPU_DIRECT_RDMA_ENABLED}" = "true" ]; then
+        # check if mellanox cards are present
+        if  _mellanox_devices_present; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# For each kernel module configuration file mounted into the container,
+# parse the file contents and extract the custom module parameters that
+# are to be passed as input to 'modprobe'.
+#
+# Assumptions:
+# - Configuration files are named <module-name>.conf (i.e. nvidia.conf, nvidia-uvm.conf).
+# - Configuration files are mounted inside the container at /drivers.
+# - Each line in the file contains at least one parameter, where parameters on the same line
+#   are space delimited. It is up to the user to properly format the file to ensure
+#   the correct set of parameters are passed to 'modprobe'.
+_get_module_params() {
+    local base_path="/drivers"
+
+    # Starting from R580, we need to enable the CDMM (Coherent Driver Memory Management) module parameter.
+    # This prevents the GPU memory for coherent systems (GH200, GB200 etc) from being exposed as a NUMA node
+    # and thereby preventing over-reporting of a Kubernetes node's memory. This is needed for Kubernetes use-cases
+    NVIDIA_MODULE_PARAMS+=("NVreg_CoherentGPUMemoryMode=driver")
+
+    # nvidia
+    if [ -f "${base_path}/nvidia.conf" ]; then
+       while IFS="" read -r param || [ -n "$param" ]; do
+           NVIDIA_MODULE_PARAMS+=("$param")
+       done <"${base_path}/nvidia.conf"
+       echo "Module parameters provided for nvidia: ${NVIDIA_MODULE_PARAMS[@]}"
+    fi
+    # nvidia-uvm
+    if [ -f "${base_path}/nvidia-uvm.conf" ]; then
+       while IFS="" read -r param || [ -n "$param" ]; do
+           NVIDIA_UVM_MODULE_PARAMS+=("$param")
+       done <"${base_path}/nvidia-uvm.conf"
+       echo "Module parameters provided for nvidia-uvm: ${NVIDIA_UVM_MODULE_PARAMS[@]}"
+    fi
+    # nvidia-modeset
+    if [ -f "${base_path}/nvidia-modeset.conf" ]; then
+       while IFS="" read -r param || [ -n "$param" ]; do
+           NVIDIA_MODESET_MODULE_PARAMS+=("$param")
+       done <"${base_path}/nvidia-modeset.conf"
+       echo "Module parameters provided for nvidia-modeset: ${NVIDIA_MODESET_MODULE_PARAMS[@]}"
+    fi
+    # nvidia-peermem
+    if [ -f "${base_path}/nvidia-peermem.conf" ]; then
+       while IFS="" read -r param || [ -n "$param" ]; do
+           NVIDIA_PEERMEM_MODULE_PARAMS+=("$param")
+       done <"${base_path}/nvidia-peermem.conf"
+       echo "Module parameters provided for nvidia-peermem: ${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"
+    fi
+}
+
+_create_module_params_conf() {
+    echo "Parsing kernel module parameters..."
+    _get_module_params
+
+    if [ ${#NVIDIA_MODULE_PARAMS[@]} -gt 0 ]; then
+        echo "Configuring nvidia module parameters in ${MODPROBE_CONFIG_DIR}/nvidia.conf"
+        echo "options nvidia ${NVIDIA_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia.conf
+    fi
+    if [ ${#NVIDIA_UVM_MODULE_PARAMS[@]} -gt 0 ]; then
+        echo "Configuring nvidia-uvm module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf"
+        echo "options nvidia-uvm ${NVIDIA_UVM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf
+    fi
+    if [ ${#NVIDIA_MODESET_MODULE_PARAMS[@]} -gt 0 ]; then
+        echo "Configuring nvidia-modeset module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf"
+        echo "options nvidia-modeset ${NVIDIA_MODESET_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf
+    fi
+    if [ ${#NVIDIA_PEERMEM_MODULE_PARAMS[@]} -gt 0 ]; then
+        echo "Configuring nvidia-peermem module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf"
+        echo "options nvidia-peermem ${NVIDIA_PEERMEM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf
+    fi
+}
+
+# Load the kernel modules and start persistenced.
+_load_driver() {
+    local nv_fw_search_path="$RUN_DIR/driver/lib/firmware"
+    local set_fw_path="true"
+    local fw_path_config_file="/sys/module/firmware_class/parameters/path"
+    for param in "${NVIDIA_MODULE_PARAMS[@]}"; do
+        if [[ "$param" == "NVreg_EnableGpuFirmware=0" ]]; then
+          set_fw_path="false"
+        fi
+    done
+
+    if [[ "$set_fw_path" == "true" ]]; then
+        echo "Configuring the following firmware search path in '$fw_path_config_file': $nv_fw_search_path"
+        if [[ ! -z $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
+            echo "WARNING: A search path is already configured in $fw_path_config_file"
+            echo "         Retaining the current configuration"
+        else
+            echo -n "$nv_fw_search_path" > $fw_path_config_file || echo "WARNING: Failed to configure firmware search path"
+        fi
+    fi
+
+    echo "Loading ipmi and i2c_core kernel modules..."
+    modprobe -a i2c_core ipmi_msghandler ipmi_devintf
+
+    echo "Loading NVIDIA driver kernel modules..."
+    set -o xtrace +o nounset
+    modprobe nvidia
+    modprobe nvidia-uvm
+    modprobe nvidia-modeset
+    set +o xtrace -o nounset
+
+    if _gpu_direct_rdma_enabled; then
+        echo "Loading NVIDIA Peer Memory kernel module..."
+        set -o xtrace +o nounset
+        modprobe nvidia-peermem
+        set +o xtrace -o nounset
+    fi
+
+    _start_daemons
+
+    return 0
+}
+
+# Stop persistenced and unload the kernel modules if they are currently loaded.
+_unload_driver() {
+    local rmmod_args=()
+    local nvidia_deps=0
+    local nvidia_refs=0
+    local nvidia_uvm_refs=0
+    local nvidia_modeset_refs=0
+    local nvidia_peermem_refs=0
+
+    if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
+        echo "Stopping NVIDIA persistence daemon..."
+        local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
+
+        kill -SIGTERM "${pid}"
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ $i -eq 50 ]; then
+            echo "Could not stop NVIDIA persistence daemon" >&2
+            return 1
+        fi
+    fi
+
+    if [ -f /var/run/nvidia-gridd/nvidia-gridd.pid ]; then
+        echo "Stopping NVIDIA grid daemon..."
+        local pid=$(< /var/run/nvidia-gridd/nvidia-gridd.pid)
+
+        kill -SIGTERM "${pid}"
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ $i -eq 50 ]; then
+            echo "Could not stop NVIDIA Grid daemon" >&2
+            return 1
+        fi
+    fi
+
+    if [ -f /var/run/nvidia-topologyd/nvidia-topologyd.pid ]; then
+        echo "Stopping NVIDIA topology daemon..."
+        local pid=$(< /var/run/nvidia-topologyd/nvidia-topologyd.pid)
+
+        kill -SIGTERM "${pid}"
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ $i -eq 50 ]; then
+            echo "Could not stop NVIDIA topology daemon" >&2
+            return 1
+        fi
+    fi
+
+    if [ -f /var/run/nvidia-fabricmanager/nv-fabricmanager.pid ]; then
+        echo "Stopping NVIDIA fabric manager daemon..."
+        local pid=$(< /var/run/nvidia-fabricmanager/nv-fabricmanager.pid)
+
+        kill -SIGTERM "${pid}"
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ $i -eq 50 ]; then
+            echo "Could not stop NVIDIA fabric manager daemon" >&2
+            return 1
+        fi
+    fi
+
+    if [ -f /var/run/nvidia-fabricmanager/nvlsm.pid ]; then
+        echo "Stopping NVLink Subnet Manager daemon..."
+        local pid=$(< /var/run/nvidia-fabricmanager/nvlsm.pid)
+
+        kill -SIGTERM "${pid}"
+        for i in $(seq 1 50); do
+            kill -0 "${pid}" 2> /dev/null || break
+            sleep 0.1
+        done
+        if [ $i -eq 50 ]; then
+            echo "Could not stop NVLink Subnet Manager daemon" >&2
+            return 1
+        fi
+    fi
+
+    echo "Unloading NVIDIA driver kernel modules..."
+    if [ -f /sys/module/nvidia_modeset/refcnt ]; then
+        nvidia_modeset_refs=$(< /sys/module/nvidia_modeset/refcnt)
+        rmmod_args+=("nvidia-modeset")
+        ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia_uvm/refcnt ]; then
+        nvidia_uvm_refs=$(< /sys/module/nvidia_uvm/refcnt)
+        rmmod_args+=("nvidia-uvm")
+        ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        nvidia_peermem_refs=$(< /sys/module/nvidia_peermem/refcnt)
+        rmmod_args+=("nvidia-peermem")
+        ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia/refcnt ]; then
+        nvidia_refs=$(< /sys/module/nvidia/refcnt)
+        rmmod_args+=("nvidia")
+    fi
+    if [ ${nvidia_refs} -gt ${nvidia_deps} ] || [ ${nvidia_uvm_refs} -gt 0 ] || [ ${nvidia_modeset_refs} -gt 0 ] || [ ${nvidia_peermem_refs} -gt 0 ]; then
+        # run lsmod to debug module usage
+        lsmod | grep nvidia
+        echo "Could not unload NVIDIA driver kernel modules, driver is in use" >&2
+        return 1
+    fi
+
+    if [ ${#rmmod_args[@]} -gt 0 ]; then
+        rmmod ${rmmod_args[@]}
+    fi
+    return 0
+}
+
+# Install the driver, dispatching on the driver type: the vgpu type installs from the
+# user-supplied .run file, all other types install from packages.
+_install_driver() {
+    if [ "${DRIVER_TYPE}" = "vgpu" ]; then
+        _install_driver_runfile
+    else
+        _install_driver_packages
+    fi
+}
+
+# Install the NVIDIA driver metapackage; its DKMS packages build the kernel modules against the
+# running kernel. Packages resolve exclusively from the local file: apt repo baked into the
+# image; the driver userspace is already part of the image rootfs.
+_install_driver_packages() {
+    local metapkg
+
+    case "${KERNEL_MODULE_TYPE}" in
+    proprietary)
+        metapkg=cuda-drivers ;;
+    open)
+        metapkg=nvidia-open ;;
+    auto)
+        # All driver branches available on Ubuntu 26.04 (>=595) support Turing+ GPUs only,
+        # where the open kernel modules are the recommended default.
+        echo "KERNEL_MODULE_TYPE=auto resolves to open on Ubuntu 26.04"
+        metapkg=nvidia-open ;;
+    *)
+        echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}" >&2
+        return 1 ;;
+    esac
+
+    echo "Installing NVIDIA driver metapackage ${metapkg} (kernel modules built via DKMS)..."
+    _update_local_repo_lists
+    apt-get install -y --no-install-recommends "${metapkg}"
+
+    # The kernel reads the GSP firmware from the host filesystem, not from the container.
+    # The GPU operator's driver DaemonSet therefore mounts a host directory at /lib/firmware
+    # and points the kernel's firmware search path at it. That mount hides the firmware files
+    # installed at image build, so reinstall nvidia-firmware here: dpkg writes the files
+    # again, and they land in the mounted host directory where the kernel looks for them.
+    # The .run installer gets the same result by writing the firmware at install time.
+    apt-get install --reinstall -y --no-install-recommends nvidia-firmware
+
+    # Normally a no-op: the metapackage postinst already built and installed the modules for the
+    # running kernel. It exits 0 even when it skips the build, so rerun dkms for exactly
+    # KERNEL_VERSION to surface any failure. MAX_THREADS is not honored here: the NVIDIA
+    # dkms.conf hardcodes -j$(nproc), so dkms's own -j option has no effect.
+    dkms autoinstall -k "${KERNEL_VERSION}"
+}
+
+# Install the driver and build the kernel modules using the .run installer (vgpu driver type).
+_install_driver_runfile() {
+    local install_args=()
+
+    if [ "${ACCEPT_LICENSE}" = "yes" ]; then
+        install_args+=("--accept-license")
+    fi
+
+    if [ -n "${MAX_THREADS}" ]; then
+        install_args+=("--concurrency-level=${MAX_THREADS}")
+    fi
+
+    if [[ "${KERNEL_MODULE_TYPE}" == "open"  || "${KERNEL_MODULE_TYPE}" == "proprietary" ]]; then
+        [[ "${KERNEL_MODULE_TYPE}" == "open" ]] && kernel_type=kernel-open || kernel_type=kernel
+        echo "Proceeding with user-specified kernel module type ${KERNEL_MODULE_TYPE}"
+        install_args+=("-m=${kernel_type}")
+    fi
+
+    # Always pass --skip-module-load; every driver branch available on Ubuntu 26.04
+    # supports it. From the nvidia-installer help output:
+    #
+    #    --skip-module-load
+    #         Skip the test load of the NVIDIA kernel modules after the modules are built,
+    #         and skip loading them after installation is complete.
+    #
+    # Without this flag, a subtle bug can occur if the nvidia-installer fails to unload
+    # the NVIDIA kernel modules after the test load. The modules will remain loaded and
+    # any custom NVIDIA module parameters configured as input to the driver container
+    # will not be applied.
+    #
+    install_args+=("--skip-module-load")
+
+    # Install the NVIDIA driver in one step
+    sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
+                    --ui=none \
+                    --no-drm \
+                    --no-nouveau-check \
+                    --no-nvidia-modprobe \
+                    --no-rpms \
+                    --no-backup \
+                    --no-check-for-alternate-installs \
+                    --no-libglx-indirect \
+                    --no-install-libglvnd \
+                    --x-prefix=/tmp/null \
+                    --x-module-path=/tmp/null \
+                    --x-library-path=/tmp/null \
+                    --x-sysconfig-path=/tmp/null \
+                    ${install_args[@]+"${install_args[@]}"}
+}
+
+# Mount the driver rootfs into the run directory with the exception of sysfs.
+_mount_rootfs() {
+    echo "Mounting NVIDIA driver rootfs..."
+    mount --make-runbindable /sys
+    mount --make-private /sys
+    mkdir -p ${RUN_DIR}/driver
+    mount --rbind / ${RUN_DIR}/driver
+}
+
+# Unmount the driver rootfs from the run directory.
+_unmount_rootfs() {
+    echo "Unmounting NVIDIA driver rootfs..."
+    if findmnt -r -o TARGET | grep "${RUN_DIR}/driver" > /dev/null; then
+        umount -l -R ${RUN_DIR}/driver
+    fi
+}
+
+# Write a kernel postinst.d script to automatically precompile packages on kernel update (similar to DKMS).
+_write_kernel_update_hook() {
+    if [ ! -d ${KERNEL_UPDATE_HOOK%/*} ]; then
+        return
+    fi
+
+    echo "Writing kernel update hook..."
+    cat > ${KERNEL_UPDATE_HOOK} <<'EOF'
+#!/bin/bash
+
+set -eu
+trap 'echo "ERROR: Failed to update the NVIDIA driver" >&2; exit 0' ERR
+
+NVIDIA_DRIVER_PID=$(< /run/nvidia/nvidia-driver.pid)
+
+export "$(grep -z DRIVER_VERSION /proc/${NVIDIA_DRIVER_PID}/environ)"
+nsenter -t "${NVIDIA_DRIVER_PID}" -m -- nvidia-driver update --kernel "$1"
+EOF
+    chmod +x ${KERNEL_UPDATE_HOOK}
+}
+
+_shutdown() {
+    if _unload_driver; then
+        _unmount_rootfs
+        rm -f ${PID_FILE} ${KERNEL_UPDATE_HOOK}
+        return 0
+    fi
+    return 1
+}
+
+_find_vgpu_driver_version() {
+    local count=""
+    local version=""
+
+    if [ "${DISABLE_VGPU_VERSION_CHECK}" = "true" ]; then
+        echo "vgpu version compatibility check is disabled"
+        return 0
+    fi
+    # check if vgpu devices are present
+    count=$(vgpu-util count)
+    if [ $? -ne 0 ]; then
+         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
+         return 0
+    fi
+    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
+    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
+        # no vgpu devices found, treat as passthrough
+        return 0
+    fi
+    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
+
+    # find compatible guest driver using drive catalog
+    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
+    if [ $? -ne 0 ]; then
+        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
+        return 1
+    fi
+    DRIVER_VERSION=$(echo "$version" | awk -F= '{print $2}')
+    echo "vgpu driver version selected: ${DRIVER_VERSION}"
+    return 0
+}
+
+_start_vgpu_topology_daemon() {
+    type nvidia-topologyd > /dev/null 2>&1 || return 0
+    echo "Starting nvidia-topologyd.."
+    nvidia-topologyd
+}
+
+_start_daemons() {
+    echo "Starting NVIDIA persistence daemon..."
+    nvidia-persistenced --persistence-mode
+
+    if [ "${DRIVER_TYPE}" = "vgpu" ]; then
+        echo "Copying gridd.conf..."
+        cp /drivers/gridd.conf /etc/nvidia/gridd.conf
+        if [ "${VGPU_LICENSE_SERVER_TYPE}" = "NLS" ]; then
+            echo "Copying ClientConfigToken..."
+            mkdir -p  /etc/nvidia/ClientConfigToken/
+            cp /drivers/ClientConfigToken/* /etc/nvidia/ClientConfigToken/
+        fi
+
+        echo "Starting nvidia-gridd.."
+        LD_LIBRARY_PATH=/usr/lib/$DRIVER_ARCH-linux-gnu/nvidia/gridd nvidia-gridd
+
+        # Start virtual topology daemon
+        _start_vgpu_topology_daemon
+    fi
+
+    if _assert_nvlink5_system; then
+        _ensure_nvlink5_prerequisites || return 1
+        echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
+
+        fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+        fm_pid_file=/var/run/nvidia-fabricmanager/nv-fabricmanager.pid
+        nvlsm_config_file=/usr/share/nvidia/nvlsm/nvlsm.conf
+        nvlsm_pid_file=/var/run/nvidia-fabricmanager/nvlsm.pid
+        /usr/bin/nvidia-fabricmanager-start.sh --mode start \
+                                               --fm-config-file $fm_config_file \
+                                               --fm-pid-file $fm_pid_file \
+                                               --nvlsm-config-file $nvlsm_config_file \
+                                               --nvlsm-pid-file $nvlsm_pid_file
+
+    # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
+    elif _assert_nvswitch_system; then
+        echo "Starting NVIDIA fabric manager daemon..."
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+    fi
+}
+
+# Check if fast path should be used (driver already loaded with matching config)
+# Compares current digest from DRIVER_CONFIG_DIGEST env var with stored digest
+_should_skip_kernel_module_reload() {
+    [ -f /sys/module/nvidia/refcnt ] && [ -f /run/nvidia/nvidia-driver.state ] || return 1
+    local current_digest="${DRIVER_CONFIG_DIGEST:-}"
+    [ -z "${current_digest}" ] && return 1
+    local stored_digest=$(cat /run/nvidia/nvidia-driver.state 2>/dev/null || echo "")
+    [ "${current_digest}" = "${stored_digest}" ]
+}
+
+_store_driver_digest() {
+    local digest_file="${RUN_DIR}/nvidia-driver.state"
+    local current_digest="${DRIVER_CONFIG_DIGEST:-}"
+    echo "Storing driver configuration digest..."
+    echo "${current_digest}" > "$digest_file"
+    echo "Driver configuration digest stored at $digest_file"
+}
+
+_install_userspace_components() {
+    echo "Installing userspace components (libraries and binaries)..."
+    cd /drivers
+    sh NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}.run -x
+    cd NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}
+    ./nvidia-installer \
+        --silent \
+        --no-kernel-module \
+        --no-nouveau-check \
+        --no-nvidia-modprobe \
+        --no-rpms \
+        --no-backup \
+        --no-check-for-alternate-installs \
+        --no-libglx-indirect \
+        --no-install-libglvnd \
+        --x-prefix=/tmp/null \
+        --x-module-path=/tmp/null \
+        --x-library-path=/tmp/null \
+        --x-sysconfig-path=/tmp/null
+}
+
+_resolve_kernel_type() {
+  if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
+    KERNEL_TYPE=kernel
+  elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
+    KERNEL_TYPE=kernel-open
+  elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
+    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
+    if [ $? -ne 0 ]; then
+      echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
+      _resolve_kernel_type_from_driver_branch
+      return 0
+    fi
+    [[ "${kernel_module_type}" == "open" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
+  else
+    echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}"
+    return 1
+  fi
+}
+
+_resolve_kernel_type_from_driver_branch() {
+  [[ "${DRIVER_BRANCH}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
+}
+
+_move_kernel_module_sources() {
+    mkdir -p /usr/src/nvidia-${DRIVER_VERSION}
+    mv LICENSE mkprecompiled ${KERNEL_TYPE} /usr/src/nvidia-${DRIVER_VERSION}/
+    sed '9,${/^\(kernel\|LICENSE\)/!d}' .manifest > /usr/src/nvidia-${DRIVER_VERSION}/.manifest
+}
+
+# Reinstall or sync the driver userspace on the fast path (the kernel modules stay loaded),
+# dispatching on the driver type: the vgpu type reinstalls the userspace from the .run file,
+# all other types carry the userspace in the image rootfs and only sync the module sources.
+_reinstall_userspace() {
+    if [ "${DRIVER_TYPE}" = "vgpu" ]; then
+        _install_userspace_components
+        _resolve_kernel_type || return 1
+        _move_kernel_module_sources
+    else
+        _sync_kernel_module_sources
+    fi
+}
+
+# The image bakes the open-flavor kernel module sources (nvidia-kernel-source-open). When the
+# loaded modules are proprietary, install the matching source tree from the local repo so the
+# exported rootfs matches the loaded flavor. No DKMS package is installed, so no module build runs.
+_sync_kernel_module_sources() {
+    case "${KERNEL_MODULE_TYPE}" in
+    proprietary)
+        echo "Installing the proprietary kernel module sources to match the loaded kernel modules..."
+        _update_local_repo_lists
+        apt-get install -y --no-install-recommends nvidia-kernel-source
+        ;;
+    open|auto)
+        echo "Open kernel module sources are already part of the container image, nothing to install"
+        ;;
+    *)
+        echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}" >&2
+        return 1
+        ;;
+    esac
+}
+
+_wait_for_signal() {
+    echo "Done, now waiting for signal"
+    sleep infinity &
+    trap "echo 'Caught signal'; _shutdown && { kill $!; exit 0; }" HUP INT QUIT PIPE TERM
+    trap - EXIT
+    while true; do wait $! || continue; done
+    exit 0
+}
+
+init() {
+    if [ "${DRIVER_TYPE}" = "vgpu" ]; then
+        _find_vgpu_driver_version || exit 1
+    fi
+
+    echo -e "\n========== NVIDIA Software Installer ==========\n"
+    echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}"
+    echo -e "Kernel module type: ${KERNEL_MODULE_TYPE}\n"
+
+    exec 3> ${PID_FILE}
+    if ! flock -n 3; then
+        echo "An instance of the NVIDIA driver is already running, aborting"
+        exit 1
+    fi
+    echo $$ >&3
+
+    trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    trap "_shutdown" EXIT
+
+    if _should_skip_kernel_module_reload; then
+        echo "The NVIDIA driver is already loaded with the desired configuration, performing userspace-only install"
+        _unmount_rootfs
+        _reinstall_userspace
+        # Mount the rootfs before starting the daemons: persistenced initializes the GPUs on
+        # startup, and a GPU that deinitialized across the restart needs its GSP firmware,
+        # which the kernel reads through the exported rootfs (the firmware search path points
+        # at /run/nvidia/driver/lib/firmware).
+        _mount_rootfs
+        _start_daemons
+        _write_kernel_update_hook
+        _store_driver_digest
+        echo "Userspace-only install complete"
+        _wait_for_signal
+    fi
+
+    # Full install path: unload existing driver and perform complete installation
+    _unload_driver || exit 1
+    _unmount_rootfs
+
+    _update_ca_certificates
+    _update_package_cache
+    _enable_fips_if_required
+    _resolve_kernel_version || exit 1
+    _install_prerequisites
+    _link_ofa_kernel
+
+    _create_module_params_conf
+    _install_driver
+    _load_driver || exit 1
+    _mount_rootfs
+    _write_kernel_update_hook
+    _store_driver_digest
+    _wait_for_signal
+}
+
+# Wait for MOFED drivers to be loaded and load nvidia-peermem whenever it gets unloaded during MOFED driver updates
+reload_nvidia_peermem() {
+    if [ "$USE_HOST_MOFED" = "true" ]; then
+        until  lsmod | grep mlx5_core > /dev/null 2>&1 && [ -f /run/nvidia/validations/.driver-ctr-ready ];
+        do
+            echo "waiting for mellanox ofed and nvidia drivers to be installed"
+            sleep 10
+        done
+    else
+        # use driver readiness flag created by MOFED container
+        until  [ -f /run/mellanox/drivers/.driver-ready ] && [ -f /run/nvidia/validations/.driver-ctr-ready ];
+        do
+            echo "waiting for mellanox ofed and nvidia drivers to be installed"
+            sleep 10
+        done
+    fi
+    # get any parameters provided for nvidia-peermem
+    _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+    fi
+    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
+        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+            echo "successfully loaded nvidia-peermem module, now waiting for signal"
+            sleep inf
+            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+        fi
+    fi
+    echo "failed to load nvidia-peermem module"
+    exit 1
+}
+
+# probe by gpu-opertor for liveness/startup checks for nvidia-peermem module to be loaded when MOFED drivers are ready
+probe_nvidia_peermem() {
+    if lsmod | grep mlx5_core > /dev/null 2>&1; then
+        if [ ! -f /sys/module/nvidia_peermem/refcnt ]; then
+            echo "nvidia-peermem module is not loaded"
+            return 1
+        fi
+    else
+        echo "MOFED drivers are not ready, skipping probe to avoid container restarts..."
+    fi
+    return 0
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 COMMAND [ARG...]
+
+Commands:
+  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+EOF
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+command=$1; shift
+case "${command}" in
+    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    reload_nvidia_peermem) options="" ;;
+    probe_nvidia_peermem) options="" ;;
+    *) usage ;;
+esac
+if [ $? -ne 0 ]; then
+    usage
+fi
+eval set -- "${options}"
+
+ACCEPT_LICENSE=""
+MAX_THREADS=""
+KERNEL_VERSION=$(uname -r)
+PACKAGE_TAG=""
+
+for opt in ${options}; do
+    case "$opt" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
+    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
+    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
+    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+    --) shift; break ;;
+    esac
+done
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+$command


### PR DESCRIPTION
Adds a new `ubuntu26.04/` driver container. For the passthrough (baremetal) driver type it
installs the NVIDIA driver from apt packages in the `ubuntu2604` CUDA repository and builds the
kernel modules with DKMS, replacing the `.run` installer. The vGPU driver type keeps the existing
`.run` flow.

## How it works

**Image build** installs the driver userspace (`nvidia-headless-no-dkms-open` plus the
display/codec libraries, matching what the `.run` file ships today) and the extra
packages (fabricmanager, nscq, imex, nvlsm, libnvsdm). It also downloads the driver metapackages,
the DKMS/kernel-source packages for both kernel module flavors, and `nvidia-firmware` (~185 MB
total) into a local `file:` apt repository baked into the image, then removes the CUDA network
repository so NVIDIA packages resolve only from the local one.

**Container start** installs the flavor-appropriate driver metapackage from the local
repository — `nvidia-open` for open, `cuda-drivers` for proprietary. At runtime, `apt`
skips everything already installed at build, so only the DKMS and kernel-source packages
are installed, and DKMS builds the modules against the host kernel headers.
`nvidia-firmware` is reinstalled at container start: the GPU operator mounts `/lib/firmware` in
the driver container from the host so the kernel can read the GSP firmware, and that mount
hides the copy installed at image build. The reinstall writes the files into the mounted host
directory, which the `.run` installer achieves by writing the firmware at install time. The fast path
mounts the driver rootfs before starting the daemons so that GPU initialization always finds the firmware.
`dkms autoinstall -k $(uname -r)` runs afterwards as a check: the DKMS package postinst
exits 0 even when it skips the build, so this rerun surfaces any build failure and fails init
instead of continuing without modules.

**Fast path** (driver already loaded, configuration unchanged) installs nothing: no apt, no
network. Runtime network access is needed only for kernel headers, same as the `.run` flow.

## Package landscape

The two NVIDIA-documented install entry points are `nvidia-open` (open) and `cuda-drivers`
(proprietary). Both are empty metapackage shims whose dependency trees share the userspace
and differ only in the kernel-module rows at the bottom:

```
nvidia-open (shim)                          cuda-drivers (shim)
└── nvidia-driver-open (shim)               └── nvidia-driver (shim)
    ├── libnvidia-compute  ← nvidia-smi, NVML, libcuda, MPS ──┐
    │     └── nvidia-persistenced                             │
    ├── libnvidia-gl (273 MB: GLX/EGL/Vulkan ICDs)            │  identical
    ├── libnvidia-decode / libnvidia-encode / libnvidia-fbc1  │  userspace
    ├── nvidia-kernel-common                                  │  on both
    │     ├── nvidia-firmware  ← GSP firmware                 │  sides
    │     └── nvidia-modprobe ────────────────────────────────┘
    │
    ├── nvidia-kernel-source-open   |   ├── nvidia-kernel-source (~88 MB)
    └── nvidia-dkms-open            |   └── nvidia-dkms
          └── dkms (make, patch, …) |         └── dkms
```

`nvidia-kernel-source[-open]` is the module source tree under `/usr/src`; `nvidia-dkms[-open]`
registers it with DKMS. The two flavors are mutually exclusive (`nvidia-kernel-source-open`
declares `Provides/Conflicts/Replaces: nvidia-kernel-source`). This makes the runtime
kernel module type change just an `apt-get install`.

The same trees split by install time: the left side carries the `open` tree's dependencies,
the right side contains the `proprietary` tree's. The packages that come via
`nvidia-headless-no-dkms-open` are boxed.

```
CONTAINER START — installed from the local file: repo, per KERNEL_MODULE_TYPE
═══════════════════════════════════════════════════════════════════════════════════
 open/auto: 3 debs, <100 KB                proprietary: 4 debs, ~89 MB

 nvidia-open (shim)                        cuda-drivers (shim)
 └── nvidia-driver-open (shim)             └── nvidia-driver (shim)
     ├── nvidia-dkms-open                      ├── nvidia-dkms
     │                                         ├── nvidia-kernel-source (~88 MB)
     │                                         │     evicts nvidia-kernel-source-open
     │                                         └──────────────────────────────────┐
═════╪════════════════════════════════════════════════════════════════════════════╪
     │  BUILD TIME — userspace_install, baked into the image rootfs (~1 GB)       │
     │   ┌─ via nvidia-headless-no-dkms-open (shim) ──────────────────────────┐   │
     ├───┼─ libnvidia-compute          ← nvidia-smi, NVML, libcuda, MPS       ┼───┤
     │   │    └── nvidia-persistenced                                         │   │
     ├───┼─ nvidia-kernel-common                                              ┼───┤
     │   │    ├── nvidia-firmware       ← GSP firmware                        │   │
     │   │    └── nvidia-modprobe                                             │   │
     ├───┼─ nvidia-kernel-source-open  ← open module source; open tree only   │   │
     │   └────────────────────────────────────────────────────────────────────┘   │
     │   ┌─ added explicitly (the headless shim omits them) ──────────────────┐   │
     ├───┼─ libnvidia-gl (273 MB)      ← GLX/EGL/Vulkan ICDs                  ┼───┤
     ├───┼─ libnvidia-decode / libnvidia-encode / libnvidia-fbc1              ┼───┤
     │   │   libnvidia-extra            (outside both metapackage trees)      │   │
     └───┼─ dkms                       ← via nvidia-dkms[-open]               ┼───┘
         └────────────────────────────────────────────────────────────────────┘
 left side = nvidia-driver-open (open)
 right side = nvidia-driver (proprietary)
```

All userspace packages are installed at build time. Container start adds only the metapackage
shims and the DKMS packages that build the kernel modules.

## Design decisions

1. **Install from packages, not the `.run` file (passthrough only).** Removes the
   `.run`/`nvidia-installer` dependency for the passthrough type.

2. **Driver metapackage plus a version pinning package, not a curated package list.** The build
   installs `nvidia-driver-pinning-<version>`, which pins the whole driver tree (driver
   metapackage, persistenced, fabricmanager, nscq, imex, libnvsdm) to the exact release, so builds
   are reproducible without hand-pinning each package. The metapackage is the NVIDIA-documented
   install path and needs no changes when package names change.

3. **Full driver, not headless.** `libnvidia-gl`, `libnvidia-decode`/`encode`/`fbc1` and the EGL
   libraries are kept for parity with the `.run` image. Graphics workloads consume them from the
   driver rootfs.

4. **`KERNEL_MODULE_TYPE=auto` resolves to open; no runtime detection.** Every driver branch in
   the `ubuntu2604` repository (>= 595) supports Turing+ GPUs only, where the open modules are the
   recommended default, so detection via `nvidia-installer --print-recommended-kernel-module-type`
   would always return "open". Proprietary remains an explicit opt-in (`cuda-drivers`).

5. **vGPU keeps the `.run` flow.** vGPU guest drivers need to be installed using `.run` files from
   the licensing portal with no package equivalent. Only the install step differs between the two
   types; module load, daemons, and the rootfs mount are shared.

6. **Driver payload baked into the image; no network dependency at container start.** Installing
   from the network CUDA repository at runtime would have made every container restart depend on
   repository access, which is a regression from the `.run` image where the fast path works offline.
   Cost: 0.84 GB compressed (amd64) vs 0.68 GB for the ubuntu24.04 `.run` image built from the
   same commit (arm64: 0.83 GB vs 0.60 GB).

## CI

- GitHub image build matrix includes ubuntu26.04, excluding the 580 driver (the `ubuntu2604`
  repository carries only branches >= 595).
- Renovate pins the base image to `resolute` tags.
- The QEMU emulator for arm64 cross-builds is now pinned per distribution. The previous
  `tonistiigi/binfmt:qemu-v6.2.0` pin (December 2021) cannot run the Ubuntu 26.04 arm64
  userland: the build hangs indefinitely, with no output, at the first apt layer under
  emulation. `qemu-v8.1.5` fixes that but segfaults in `libc-bin` on Ubuntu 22.04
  ([tonistiigi/binfmt#240](https://github.com/tonistiigi/binfmt/issues/240)), so no single
  version covers both. ubuntu22.04 keeps `qemu-v6.2.0`; every other distribution uses
  `qemu-v8.1.5` (all passed CI on it).

## Known limitations

- `init -m` / `MAX_THREADS` is not honored on the package path: the NVIDIA `dkms.conf` hardcodes
  `-j$(nproc)`, so DKMS's own `-j` option has no effect. The vGPU `.run` path still honors it via
  `--concurrency-level`.

## Testing

<!-- fill in / check off before opening the PR -->
- [x] Local image build (amd64)
- [x] Container start on a GPU node: open flavor
- [x] Container start: proprietary flavor (`KERNEL_MODULE_TYPE=proprietary`)
- [x] Offline container start (no network): first boot and fast path
- [x] vGPU `.run` flow unchanged
- [x] arm64 (sbsa) build
