### PR TITLE
[precompiled]: rebuild/overwrite the image even if the tag already exists

### DIFF
--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -200,6 +200,9 @@ jobs:
           DIST: ${{ matrix.dist }}
           GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
           LTS_KERNEL: ${{ matrix.lts_kernel }}
+          # Set FORCE_PUSH=true (Settings > Secrets and variables > Actions > Variables)
+          # to rebuild/e2e/overwrite already-published precompiled images
+          FORCE_PUSH: ${{ vars.FORCE_PUSH }}
         run: |
           kernel_flavors_json='${{ needs.set-driver-version-matrix.outputs.kernel_flavors }}'
           KERNEL_FLAVORS=($(echo "$kernel_flavors_json" | jq -r '.[]'))

--- a/tests/scripts/findkernelversion.sh
+++ b/tests/scripts/findkernelversion.sh
@@ -31,13 +31,18 @@ if [ -n "$artifact" ]; then
     fi
 fi
 
-# calculate driver tag
-status_nvcr=0
-status_ghcr=0
-regctl tag ls  nvcr.io/nvidia/driver | grep "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$" || status_nvcr=$?
-regctl tag ls  ghcr.io/nvidia/driver | grep "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$" || status_ghcr=$?
-if [[ $status_nvcr -eq 0 || $status_ghcr -eq 0 ]]; then
-    export should_continue=false
-else
+# When FORCE_PUSH is set, rebuild/overwrite the image even if the tag already exists
+if [[ "${FORCE_PUSH}" == "true" ]]; then
     export should_continue=true
+else
+    # calculate driver tag
+    status_nvcr=0
+    status_ghcr=0
+    regctl tag ls  nvcr.io/nvidia/driver | grep "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$" || status_nvcr=$?
+    regctl tag ls  ghcr.io/nvidia/driver | grep "^${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}$" || status_ghcr=$?
+    if [[ $status_nvcr -eq 0 || $status_ghcr -eq 0 ]]; then
+        export should_continue=false
+    else
+        export should_continue=true
+    fi
 fi


### PR DESCRIPTION
Add FORCE_PUSH override to overwrite already-published precompiled images

Issue: When a CVE is found during a release and the precompiled image is already published, the pipelines skip re-pushing because the image tag already exists. If no new kernel has been released, there is no way to rebuild and overwrite the fixed image 

Solution: Write the existing FORCE_PUSH into both scheduled pipelines(github and gitlab) so it can be toggled via a CI/CD variable. 
Setting FORCE_PUSH=true forces a rebuild, e2e test, and overwrite of the existing tag.
Unset keeps the normal skip.
