### PR TITLE
Fix precompiled image publish silently dropping non-native-arch manifests

### DIFF
--- a/.github/scripts/test-verify-manifest-match.sh
+++ b/.github/scripts/test-verify-manifest-match.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY_SCRIPT="${SCRIPT_DIR}/verify-manifest-match.sh"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+VERIFICATION_FAILED_EXIT_CODE=1
+FAILURE_COUNT=0
+
+assert_pass() {
+  local case_name=$1 local_manifest_json=$2 remote_manifest_json=$3
+  echo "$local_manifest_json" > "${WORK_DIR}/local.json"
+  echo "$remote_manifest_json" > "${WORK_DIR}/remote.json"
+  if "${VERIFY_SCRIPT}" "${WORK_DIR}/local.json" "${WORK_DIR}/remote.json" >/dev/null; then
+    echo "PASS: ${case_name}"
+  else
+    echo "FAIL: ${case_name} (expected match, script reported mismatch)"
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  fi
+}
+
+assert_fail() {
+  local case_name=$1 local_manifest_json=$2 remote_manifest_json=$3
+  local exit_code=0
+  echo "$local_manifest_json" > "${WORK_DIR}/local.json"
+  echo "$remote_manifest_json" > "${WORK_DIR}/remote.json"
+  "${VERIFY_SCRIPT}" "${WORK_DIR}/local.json" "${WORK_DIR}/remote.json" >/dev/null 2>&1 || exit_code=$?
+  if [[ "${exit_code}" -eq "${VERIFICATION_FAILED_EXIT_CODE}" ]]; then
+    echo "PASS: ${case_name}"
+  else
+    echo "FAIL: ${case_name} (expected exit ${VERIFICATION_FAILED_EXIT_CODE}, got ${exit_code})"
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  fi
+}
+
+MULTI_ARCH_INDEX='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:5861314d7fccb39c2192173240eab44fa35ca66426201ca2acd0630a6258dd51", "size": 1, "platform": {"architecture": "amd64", "os": "linux"}},
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:f69162950f235e3cdbbad33f1f912d1a504be90d8a37d002c735d6f3e3882265", "size": 1, "platform": {"architecture": "arm64", "os": "linux"}},
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:813a89a296973e35545cfa74fe3efd172a7d19443c97c625d699e9737229b0a2", "size": 1, "platform": {"architecture": "unknown", "os": "unknown"}, "annotations": {"vnd.docker.reference.type": "attestation-manifest"}}
+  ]
+}'
+
+MULTI_ARCH_INDEX_WRONG_DIGEST='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:5861314d7fccb39c2192173240eab44fa35ca66426201ca2acd0630a6258dd51", "size": 1, "platform": {"architecture": "amd64", "os": "linux"}},
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:5b8c821bfcb9a4545169cdd6e80c0b7467aefad06b3686d141e8a4eebb089001", "size": 1, "platform": {"architecture": "arm64", "os": "linux"}}
+  ]
+}'
+
+MULTI_ARCH_INDEX_DROPPED_ARCH='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:5861314d7fccb39c2192173240eab44fa35ca66426201ca2acd0630a6258dd51", "size": 1, "platform": {"architecture": "amd64", "os": "linux"}}
+  ]
+}'
+
+MULTI_ARCH_INDEX_ONLY_ATTESTATIONS='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:813a89a296973e35545cfa74fe3efd172a7d19443c97c625d699e9737229b0a2", "size": 1, "platform": {"architecture": "unknown", "os": "unknown"}, "annotations": {"vnd.docker.reference.type": "attestation-manifest"}}
+  ]
+}'
+
+ARM_VARIANTS_LOCAL='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:5ba6c8710dd1369ce61603ab9b7a81b25f92d4a9f74956ab72a7ea75884f07ee", "size": 1, "platform": {"architecture": "arm", "os": "linux", "variant": "v7"}},
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:ac232e0a336f18d13b7f1aee7080b6f08c998893c20bac239282ec8f68f4a8d6", "size": 1, "platform": {"architecture": "arm", "os": "linux", "variant": "v8"}}
+  ]
+}'
+ARM_VARIANTS_REMOTE_CROSSED='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:ac232e0a336f18d13b7f1aee7080b6f08c998893c20bac239282ec8f68f4a8d6", "size": 1, "platform": {"architecture": "arm", "os": "linux", "variant": "v7"}},
+    {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:5ba6c8710dd1369ce61603ab9b7a81b25f92d4a9f74956ab72a7ea75884f07ee", "size": 1, "platform": {"architecture": "arm", "os": "linux", "variant": "v8"}}
+  ]
+}'
+
+SINGLE_ARCH_MANIFEST='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"digest": "sha256:b79606fb3afea5bd1609ed40b622142f1c98125abcfe89a76a661b0e8e343910"},
+  "layers": [
+    {"digest": "sha256:77ea7eee3d80b1a38f83906dd3048e2689457eb90e18a7d12f839c5ae37106a2"},
+    {"digest": "sha256:95cf1a2e1698fe3ca1fcc3f653119146b271d0b62e487ec264441e886a11bd06"}
+  ]
+}'
+
+SINGLE_ARCH_MANIFEST_WRONG_LAYER='{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"digest": "sha256:b79606fb3afea5bd1609ed40b622142f1c98125abcfe89a76a661b0e8e343910"},
+  "layers": [
+    {"digest": "sha256:77ea7eee3d80b1a38f83906dd3048e2689457eb90e18a7d12f839c5ae37106a2"},
+    {"digest": "sha256:b65ca8dd8051dc117f51fd1df452e8ef107be2f84ca0f99b18c12311bd10b9c8"}
+  ]
+}'
+
+assert_pass "multi-arch index, identical" "$MULTI_ARCH_INDEX" "$MULTI_ARCH_INDEX"
+assert_fail "multi-arch index, wrong digest for one platform" "$MULTI_ARCH_INDEX" "$MULTI_ARCH_INDEX_WRONG_DIGEST"
+assert_fail "multi-arch index, dropped architecture" "$MULTI_ARCH_INDEX" "$MULTI_ARCH_INDEX_DROPPED_ARCH"
+assert_fail "same architecture, crossed variant/digest" "$ARM_VARIANTS_LOCAL" "$ARM_VARIANTS_REMOTE_CROSSED"
+assert_pass "single-arch manifest, identical" "$SINGLE_ARCH_MANIFEST" "$SINGLE_ARCH_MANIFEST"
+assert_fail "single-arch manifest, wrong layer digest" "$SINGLE_ARCH_MANIFEST" "$SINGLE_ARCH_MANIFEST_WRONG_LAYER"
+assert_fail "multi-arch index published as single-arch manifest" "$MULTI_ARCH_INDEX" "$SINGLE_ARCH_MANIFEST"
+assert_fail "index holding only attestation manifests" "$MULTI_ARCH_INDEX_ONLY_ATTESTATIONS" "$MULTI_ARCH_INDEX_ONLY_ATTESTATIONS"
+assert_fail "empty manifest files" "" ""
+
+if [[ "${FAILURE_COUNT}" -gt 0 ]]; then
+  echo "${FAILURE_COUNT} case(s) failed"
+  exit 1
+fi
+echo "All cases passed"

--- a/.github/scripts/verify-manifest-match.sh
+++ b/.github/scripts/verify-manifest-match.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <local_raw_manifest_file> <remote_raw_manifest_file>" >&2
+  exit 2
+fi
+
+INDEX_SUMMARY_FILTER='[(.manifests // [])[] | select(.platform.architecture and .platform.architecture != "unknown") | {os: .platform.os, arch: .platform.architecture, variant: (.platform.variant // null), digest: .digest}] | sort_by(.os, .arch, .variant, .digest)'
+MANIFEST_SUMMARY_FILTER='{config: .config.digest, layers: [(.layers // [])[].digest]}'
+SUMMARY_HAS_DIGESTS_FILTER='(type == "array" and length > 0) or (type == "object" and .config != null and (.layers | length) > 0)'
+
+summarize_manifest() {
+  local manifest_file=$1
+  local summary
+
+  if ! jq -e 'type == "object"' "$manifest_file" >/dev/null 2>&1; then
+    echo "ERROR: $manifest_file is not a valid JSON manifest" >&2
+    return 1
+  fi
+
+  if jq -e 'has("manifests")' "$manifest_file" >/dev/null 2>&1; then
+    summary=$(jq -c "$INDEX_SUMMARY_FILTER" "$manifest_file") || return 1
+  else
+    summary=$(jq -c "$MANIFEST_SUMMARY_FILTER" "$manifest_file") || return 1
+  fi
+
+  if ! jq -e "$SUMMARY_HAS_DIGESTS_FILTER" >/dev/null 2>&1 <<<"$summary"; then
+    echo "ERROR: $manifest_file describes no platform or layer digests" >&2
+    return 1
+  fi
+
+  printf '%s' "$summary"
+}
+
+LOCAL_SUMMARY=$(summarize_manifest "$1") || exit 1
+REMOTE_SUMMARY=$(summarize_manifest "$2") || exit 1
+
+if [[ "$LOCAL_SUMMARY" == "$REMOTE_SUMMARY" ]]; then
+  echo "OK: published manifest matches built artifact"
+else
+  echo "ERROR: manifest mismatch between artifact and published image"
+  echo "Local:  $LOCAL_SUMMARY"
+  echo "Remote: $REMOTE_SUMMARY"
+  exit 1
+fi

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,6 +23,14 @@ on:
       - release-*
 
 jobs:
+  test-verify-manifest-match:
+    runs-on: linux-amd64-cpu4
+    steps:
+      - uses: actions/checkout@v7
+        name: Check out code
+      - name: Run verify-manifest-match tests
+        run: ./.github/scripts/test-verify-manifest-match.sh
+
   image:
     runs-on: linux-amd64-cpu4
     strategy:

--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -492,9 +492,29 @@ jobs:
         if: steps.set_image_vars.outputs.run_publish == 'true'
         run: |
           image_path="./driver-images-${{ matrix.driver_branch }}-${{ env.KERNEL_VERSION }}.tar"
+          IMAGE="${PRIVATE_REGISTRY}/nvidia/driver:${{ matrix.driver_branch }}-${{ env.KERNEL_VERSION }}"
           echo "uploading  $image_path"
           if [[ "${{ github.ref == 'refs/heads/main' }}" == "true" ]]; then
-            skopeo copy --authfile "${REGISTRY_AUTH_FILE}" "oci-archive:${image_path}" docker://${PRIVATE_REGISTRY}/nvidia/driver:${{ matrix.driver_branch }}-${{ env.KERNEL_VERSION }}
+            mkdir -p /tmp/oci-image
+            tar -xf "${image_path}" -C /tmp/oci-image
+            skopeo copy --all --authfile "${REGISTRY_AUTH_FILE}" "oci:/tmp/oci-image" docker://${IMAGE}
+
+            # Verify published manifest matches the built OCI artifact by comparing
+            # platform digests — ensures skopeo copy pushed all manifests correctly
+            LOCAL=$(skopeo inspect --raw "oci:/tmp/oci-image" | \
+              jq -c '[.manifests[]? | {arch: .platform.architecture, digest: .digest}] | sort_by(.arch)')
+            REMOTE=$(skopeo inspect --raw "docker://${IMAGE}" | \
+              jq -c '[.manifests[]? | {arch: .platform.architecture, digest: .digest}] | sort_by(.arch)')
+            if [[ "$LOCAL" == "$REMOTE" ]]; then
+              echo "OK: published manifest matches built artifact"
+            else
+              echo "ERROR: manifest mismatch between artifact and published image"
+              echo "Local:  $LOCAL"
+              echo "Remote: $REMOTE"
+              exit 1
+            fi
+
+            rm -rf /tmp/oci-image
           else
             echo "Skipping image push for non-main branch ${{ github.ref }}"
           fi

--- a/.github/workflows/precompiled.yaml
+++ b/.github/workflows/precompiled.yaml
@@ -495,26 +495,11 @@ jobs:
           IMAGE="${PRIVATE_REGISTRY}/nvidia/driver:${{ matrix.driver_branch }}-${{ env.KERNEL_VERSION }}"
           echo "uploading  $image_path"
           if [[ "${{ github.ref == 'refs/heads/main' }}" == "true" ]]; then
-            mkdir -p /tmp/oci-image
-            tar -xf "${image_path}" -C /tmp/oci-image
-            skopeo copy --all --authfile "${REGISTRY_AUTH_FILE}" "oci:/tmp/oci-image" docker://${IMAGE}
+            skopeo copy --all --authfile "${REGISTRY_AUTH_FILE}" "oci-archive:${image_path}" "docker://${IMAGE}"
 
-            # Verify published manifest matches the built OCI artifact by comparing
-            # platform digests — ensures skopeo copy pushed all manifests correctly
-            LOCAL=$(skopeo inspect --raw "oci:/tmp/oci-image" | \
-              jq -c '[.manifests[]? | {arch: .platform.architecture, digest: .digest}] | sort_by(.arch)')
-            REMOTE=$(skopeo inspect --raw "docker://${IMAGE}" | \
-              jq -c '[.manifests[]? | {arch: .platform.architecture, digest: .digest}] | sort_by(.arch)')
-            if [[ "$LOCAL" == "$REMOTE" ]]; then
-              echo "OK: published manifest matches built artifact"
-            else
-              echo "ERROR: manifest mismatch between artifact and published image"
-              echo "Local:  $LOCAL"
-              echo "Remote: $REMOTE"
-              exit 1
-            fi
-
-            rm -rf /tmp/oci-image
+            skopeo inspect --raw "oci-archive:${image_path}" > ./local-manifest.json
+            skopeo inspect --raw --authfile "${REGISTRY_AUTH_FILE}" "docker://${IMAGE}" > ./remote-manifest.json
+            .github/scripts/verify-manifest-match.sh ./local-manifest.json ./remote-manifest.json
           else
             echo "Skipping image push for non-main branch ${{ github.ref }}"
           fi


### PR DESCRIPTION
The publish step for precompiled driver images used `skopeo copy oci-archive:file.tar docker://...` without `--all`. For a multi-platform (amd64+arm64) OCI archive, skopeo doesn't error on that, it silently collapses to a single current-arch manifest, so the pushed image only had one architecture even though the build produced both.

Fix: add `--all` to the existing `oci-archive:` copy. I verified locally against the exact skopeo version CI installs (1.13.3+ds1-2ubuntu0.24.04.3, pulled from a real scheduled run's logs) and against a real push to `ghcr.io` that `--all` alone is enough, no need to extract the archive to an `oci:` directory first like the original fix did.

Also kept and adjusted the post-publish verification, since a `skopeo copy` that exits 0 isn't proof the full index was published (that's exactly how this bug shipped unnoticed in the first place). It compares the local artifact's manifest against what's actually live in the registry, and now handles both shapes correctly: an index (the multi-arch legs) compares per-platform digests, a plain manifest (ubuntu22.04, ubuntu26.04, and ubuntu24.04 azure-fde, which build amd64-only per `multi-arch.mk`) compares config/layer digests instead of silently passing on `[] == []`.

One correction on the linked skopeo issue: that issue is a different, still-open failure (a hard crash on a flat index with no attestation manifests), not the silent-drop behavior described above. Related context, but not the exact bug we're hitting here, that's just the missing `--all` flag.
