### PR TITLE
add support for overriding fields in fabricmanager.cfg

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -708,6 +708,38 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_configure_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+    local nvfm_env_vars
+    nvfm_env_vars=$(env | grep '^NVFM_CONFIG_' || true)
+    [ -z "${nvfm_env_vars}" ] && return 0
+
+    if [ ! -f "${fm_config_file}" ]; then
+        echo "WARNING: ${fm_config_file} not found; cannot configure Fabric Manager"
+        return 0
+    fi
+
+    while IFS='=' read -r name value; do
+        local field="${name#NVFM_CONFIG_}"
+        if [ -z "${field}" ]; then
+            echo "WARNING: ignoring environment variable '${name}=' with an empty config field name"
+            continue
+        fi
+        echo "Setting Fabric Manager config ${field}=${value} in ${fm_config_file}"
+        if grep -q "^${field}=" "${fm_config_file}"; then
+            # Escape characters that are special in the replacement half of a sed
+            # s||| command (backslash, ampersand and the '|' delimiter) so that a
+            # value cannot corrupt the substitution or inject extra sed commands.
+            local sed_escaped_value
+            sed_escaped_value=$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')
+            sed -i "s|^${field}=.*|${field}=${sed_escaped_value}|" "${fm_config_file}"
+        else
+            printf '\n%s=%s\n' "${field}" "${value}" >> "${fm_config_file}"
+        fi
+    done <<< "${nvfm_env_vars}"
+}
+
 _start_daemons() {
     echo "Starting NVIDIA persistence daemon..."
     nvidia-persistenced --persistence-mode
@@ -730,6 +762,7 @@ _start_daemons() {
 
     if _assert_nvlink5_system; then
         _ensure_nvlink5_prerequisites || return 1
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
 
         fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -744,6 +777,7 @@ _start_daemons() {
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
     fi

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -685,6 +685,38 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_configure_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+    local nvfm_env_vars
+    nvfm_env_vars=$(env | grep '^NVFM_CONFIG_' || true)
+    [ -z "${nvfm_env_vars}" ] && return 0
+
+    if [ ! -f "${fm_config_file}" ]; then
+        echo "WARNING: ${fm_config_file} not found; cannot configure Fabric Manager"
+        return 0
+    fi
+
+    while IFS='=' read -r name value; do
+        local field="${name#NVFM_CONFIG_}"
+        if [ -z "${field}" ]; then
+            echo "WARNING: ignoring environment variable '${name}=' with an empty config field name"
+            continue
+        fi
+        echo "Setting Fabric Manager config ${field}=${value} in ${fm_config_file}"
+        if grep -q "^${field}=" "${fm_config_file}"; then
+            # Escape characters that are special in the replacement half of a sed
+            # s||| command (backslash, ampersand and the '|' delimiter) so that a
+            # value cannot corrupt the substitution or inject extra sed commands.
+            local sed_escaped_value
+            sed_escaped_value=$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')
+            sed -i "s|^${field}=.*|${field}=${sed_escaped_value}|" "${fm_config_file}"
+        else
+            printf '\n%s=%s\n' "${field}" "${value}" >> "${fm_config_file}"
+        fi
+    done <<< "${nvfm_env_vars}"
+}
+
 _start_daemons() {
     echo "Starting NVIDIA persistence daemon..."
     nvidia-persistenced --persistence-mode
@@ -707,6 +739,7 @@ _start_daemons() {
 
     if _assert_nvlink5_system; then
         _ensure_nvlink5_prerequisites || return 1
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
 
         fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -721,6 +754,7 @@ _start_daemons() {
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
     fi

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -704,6 +704,38 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_configure_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+    local nvfm_env_vars
+    nvfm_env_vars=$(env | grep '^NVFM_CONFIG_' || true)
+    [ -z "${nvfm_env_vars}" ] && return 0
+
+    if [ ! -f "${fm_config_file}" ]; then
+        echo "WARNING: ${fm_config_file} not found; cannot configure Fabric Manager"
+        return 0
+    fi
+
+    while IFS='=' read -r name value; do
+        local field="${name#NVFM_CONFIG_}"
+        if [ -z "${field}" ]; then
+            echo "WARNING: ignoring environment variable '${name}=' with an empty config field name"
+            continue
+        fi
+        echo "Setting Fabric Manager config ${field}=${value} in ${fm_config_file}"
+        if grep -q "^${field}=" "${fm_config_file}"; then
+            # Escape characters that are special in the replacement half of a sed
+            # s||| command (backslash, ampersand and the '|' delimiter) so that a
+            # value cannot corrupt the substitution or inject extra sed commands.
+            local sed_escaped_value
+            sed_escaped_value=$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')
+            sed -i "s|^${field}=.*|${field}=${sed_escaped_value}|" "${fm_config_file}"
+        else
+            printf '\n%s=%s\n' "${field}" "${value}" >> "${fm_config_file}"
+        fi
+    done <<< "${nvfm_env_vars}"
+}
+
 _start_daemons() {
     echo "Starting NVIDIA persistence daemon..."
     nvidia-persistenced --persistence-mode
@@ -726,6 +758,7 @@ _start_daemons() {
 
     if _assert_nvlink5_system; then
         _ensure_nvlink5_prerequisites || return 1
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
 
         fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -740,6 +773,7 @@ _start_daemons() {
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
     fi

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -649,6 +649,38 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_configure_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+    local nvfm_env_vars
+    nvfm_env_vars=$(env | grep '^NVFM_CONFIG_' || true)
+    [ -z "${nvfm_env_vars}" ] && return 0
+
+    if [ ! -f "${fm_config_file}" ]; then
+        echo "WARNING: ${fm_config_file} not found; cannot configure Fabric Manager"
+        return 0
+    fi
+
+    while IFS='=' read -r name value; do
+        local field="${name#NVFM_CONFIG_}"
+        if [ -z "${field}" ]; then
+            echo "WARNING: ignoring environment variable '${name}=' with an empty config field name"
+            continue
+        fi
+        echo "Setting Fabric Manager config ${field}=${value} in ${fm_config_file}"
+        if grep -q "^${field}=" "${fm_config_file}"; then
+            # Escape characters that are special in the replacement half of a sed
+            # s||| command (backslash, ampersand and the '|' delimiter) so that a
+            # value cannot corrupt the substitution or inject extra sed commands.
+            local sed_escaped_value
+            sed_escaped_value=$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')
+            sed -i "s|^${field}=.*|${field}=${sed_escaped_value}|" "${fm_config_file}"
+        else
+            printf '\n%s=%s\n' "${field}" "${value}" >> "${fm_config_file}"
+        fi
+    done <<< "${nvfm_env_vars}"
+}
+
 _start_daemons() {
     echo "Starting NVIDIA persistence daemon..."
     nvidia-persistenced --persistence-mode
@@ -671,6 +703,7 @@ _start_daemons() {
 
     if _assert_nvlink5_system; then
         _ensure_nvlink5_prerequisites || return 1
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
 
         fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -685,6 +718,7 @@ _start_daemons() {
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
     fi

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -577,6 +577,38 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_configure_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+    local nvfm_env_vars
+    nvfm_env_vars=$(env | grep '^NVFM_CONFIG_' || true)
+    [ -z "${nvfm_env_vars}" ] && return 0
+
+    if [ ! -f "${fm_config_file}" ]; then
+        echo "WARNING: ${fm_config_file} not found; cannot configure Fabric Manager"
+        return 0
+    fi
+
+    while IFS='=' read -r name value; do
+        local field="${name#NVFM_CONFIG_}"
+        if [ -z "${field}" ]; then
+            echo "WARNING: ignoring environment variable '${name}=' with an empty config field name"
+            continue
+        fi
+        echo "Setting Fabric Manager config ${field}=${value} in ${fm_config_file}"
+        if grep -q "^${field}=" "${fm_config_file}"; then
+            # Escape characters that are special in the replacement half of a sed
+            # s||| command (backslash, ampersand and the '|' delimiter) so that a
+            # value cannot corrupt the substitution or inject extra sed commands.
+            local sed_escaped_value
+            sed_escaped_value=$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')
+            sed -i "s|^${field}=.*|${field}=${sed_escaped_value}|" "${fm_config_file}"
+        else
+            printf '\n%s=%s\n' "${field}" "${value}" >> "${fm_config_file}"
+        fi
+    done <<< "${nvfm_env_vars}"
+}
+
 _start_daemons() {
     echo "Starting NVIDIA persistence daemon..."
     nvidia-persistenced --persistence-mode
@@ -599,6 +631,7 @@ _start_daemons() {
 
     if _assert_nvlink5_system; then
         _ensure_nvlink5_prerequisites || return 1
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
 
         fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -613,6 +646,7 @@ _start_daemons() {
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
     fi

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -637,6 +637,38 @@ _start_vgpu_topology_daemon() {
     nvidia-topologyd
 }
 
+_configure_fabric_manager() {
+    local fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+    local nvfm_env_vars
+    nvfm_env_vars=$(env | grep '^NVFM_CONFIG_' || true)
+    [ -z "${nvfm_env_vars}" ] && return 0
+
+    if [ ! -f "${fm_config_file}" ]; then
+        echo "WARNING: ${fm_config_file} not found; cannot configure Fabric Manager"
+        return 0
+    fi
+
+    while IFS='=' read -r name value; do
+        local field="${name#NVFM_CONFIG_}"
+        if [ -z "${field}" ]; then
+            echo "WARNING: ignoring environment variable '${name}=' with an empty config field name"
+            continue
+        fi
+        echo "Setting Fabric Manager config ${field}=${value} in ${fm_config_file}"
+        if grep -q "^${field}=" "${fm_config_file}"; then
+            # Escape characters that are special in the replacement half of a sed
+            # s||| command (backslash, ampersand and the '|' delimiter) so that a
+            # value cannot corrupt the substitution or inject extra sed commands.
+            local sed_escaped_value
+            sed_escaped_value=$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')
+            sed -i "s|^${field}=.*|${field}=${sed_escaped_value}|" "${fm_config_file}"
+        else
+            printf '\n%s=%s\n' "${field}" "${value}" >> "${fm_config_file}"
+        fi
+    done <<< "${nvfm_env_vars}"
+}
+
 _start_daemons() {
     echo "Starting NVIDIA persistence daemon..."
     nvidia-persistenced --persistence-mode
@@ -659,6 +691,7 @@ _start_daemons() {
 
     if _assert_nvlink5_system; then
         _ensure_nvlink5_prerequisites || return 1
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon for NVLink5+..."
 
         fm_config_file=/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -673,6 +706,7 @@ _start_daemons() {
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
+        _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
     fi


### PR DESCRIPTION
Allow gpu-driver-container users to override fabric manager config before starting the fabricmanager daemon on their NVSwitch GPU systems. With this change, the gpu-driver-container will the parse environment variables with the `NVFM_CONFIG_` prefix and modify the `/usr/share/nvidia/nvswitch/fabricmanager.cfg` file with the desired fabric manager config before starting up fabricmanager.