### PR TITLE
Install packages without docs to reduce image size

### DIFF
--- a/rhel10/Dockerfile
+++ b/rhel10/Dockerfile
@@ -35,7 +35,9 @@ ENV TARGETARCH=$TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf update -y && dnf clean all
+RUN { grep -qE '^tsflags=.*nodocs' /etc/dnf/dnf.conf || \
+      dnf config-manager --save --setopt=tsflags=nodocs; } && \
+    dnf update -y && dnf clean all
 
 #ARG BASE_URL=http://us.download.nvidia.com/XFree86/Linux-x86_64
 ARG BASE_URL=https://us.download.nvidia.com/tesla

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -34,7 +34,10 @@ ENV TARGETARCH=$TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf update -y && dnf clean all
+RUN { dnf config-manager --help >/dev/null 2>&1 || \
+        dnf install -y --nodocs 'dnf-command(config-manager)'; } && \
+    dnf config-manager --save --setopt=tsflags=nodocs && \
+    dnf update -y && dnf clean all
 
 #ARG BASE_URL=http://us.download.nvidia.com/XFree86/Linux-x86_64
 ARG BASE_URL=https://us.download.nvidia.com/tesla

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -34,7 +34,9 @@ ENV TARGETARCH=$TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf update -y && dnf clean all
+RUN { grep -qE '^tsflags=.*nodocs' /etc/dnf/dnf.conf || \
+      dnf config-manager --save --setopt=tsflags=nodocs; } && \
+    dnf update -y && dnf clean all
 
 #ARG BASE_URL=http://us.download.nvidia.com/XFree86/Linux-x86_64
 ARG BASE_URL=https://us.download.nvidia.com/tesla

--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -23,7 +23,8 @@ RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
 COPY nvidia-driver /usr/local/bin
 COPY ocp_dtk_entrypoint /usr/local/bin
 
-RUN dnf install -y pciutils && \
+RUN dnf config-manager --save --setopt=tsflags=nodocs && \
+    dnf install -y pciutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 

--- a/vgpu-manager/rhel9/Dockerfile
+++ b/vgpu-manager/rhel9/Dockerfile
@@ -36,7 +36,8 @@ RUN chmod +x NVIDIA-Linux-${DRIVER_ARCH}-${DRIVER_VERSION}-vgpu-kvm.run
 COPY nvidia-driver /usr/local/bin
 COPY ocp_dtk_entrypoint /usr/local/bin
 
-RUN dnf install -y pciutils && \
+RUN dnf config-manager --save --setopt=tsflags=nodocs && \
+    dnf install -y pciutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 


### PR DESCRIPTION
Closes #773

## What

Set `tsflags=nodocs` once per RHEL image so dnf stops writing documentation and man pages into the layers we ship.

## Why

The UBI bases don't set `tsflags` in `/etc/dnf/dnf.conf`, so every `dnf install`/`dnf update` we run installs documentation with the package. It grows the image and gets flagged by CI scanners — #772 hit this with perl docs containing sample secrets. The bases themselves are clean, so the docs all come from our own install steps.

## How

Folded into the first dnf transaction of each image, so everything after it inherits the setting: the installs in `install.sh`, the `CVE_UPDATES` blocks, and the `dnf install` calls `nvidia-driver` and `ocp_dtk_entrypoint` make when the container starts. Passing `--nodocs` per command would have missed those and needed the flag on ~46 call sites.

Each Dockerfile only handles the bases it is actually built with, and the value is written through dnf's own config writer rather than by editing the file:

| Dockerfile | bases | `config-manager` | `tsflags` before | what it does |
|---|---|---|---|---|
| `rhel9`, `rhel10` | ubi9/10, rockylinux 9.8/10.2 | ubi only | rocky only | configure unless already set |
| `rhel8` | ubi8, rockylinux 8.10 | ubi only | neither | install it if absent, then configure |
| `vgpu-manager/rhel8`, `rhel9` | CUDA UBI, fixed | yes | none | configure |

Installing `config-manager` costs about 4 MiB and only happens on rockylinux 8, which is close to end of life. Everywhere else it is already present.

## Notes

- Ubuntu needs no change: its bases ship `/etc/dpkg/dpkg.cfg.d/excludes`, which already drops `/usr/share/doc` and `/usr/share/man`. This is RHEL only.
- `rm -rf /usr/share/doc/*` in `install.sh` stays. `nodocs` doesn't cover files shipped without a `%doc` marker or written outside rpm.
- The vGPU Manager images build on `nvcr.io/nvidia/cuda:*-base-ubi8/9`, which already has documentation in its parent layers. This only stops documentation from the transactions we run.
- `install_weak_deps=False` left out: it's what actually kept the perl docs out in #772, but it can silently drop a package needed at runtime. Possible follow up.

## Testing

Verified on every base image that the change lands on `tsflags=nodocs`: ubi8, ubi9, ubi10, rockylinux 8.10/9.8/10.2-ubi, and the CUDA UBI 8 and 9 bases.

Built for driver `580.178.04`, each pair back to back with `--no-cache` so both resolve the same packages:

| | before | after | saved |
|---|---|---|---|
| rhel9 | 752,585,630 | 740,277,958 | 11.74 MiB (1.64%) |
| rocky8 | 832,220,952 | 815,087,316 | 16.34 MiB (2.06%) |

rocky8 saves more despite installing `config-manager`, because it starts with more documentation. In its filesystem `/usr/share/man` goes from 1289 files to 1 (a dangling symlink) and `/usr/share/info` from 32 to 1, while all 226 `/usr/share/licenses` files are untouched. `/usr/share/doc` is empty either way, since the existing `rm -rf` already cleared it. rhel9 behaves the same, with its 237 license files intact.
