### PR TITLE
install the FabricManager SDK packages

### DIFF
--- a/rhel10/install.sh
+++ b/rhel10/install.sh
@@ -152,23 +152,20 @@ nvidia_installer () {
 }
 
 fabricmanager_install() {
-  local fabricmanager_package_name=nvidia-fabricmanager
-  dnf install -y ${fabricmanager_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${fabricmanager_package_name}
+  dnf install -y nvidia-fabricmanager-${DRIVER_VERSION} nvidia-fabric-manager-devel-${DRIVER_VERSION}
+  dnf versionlock add nvidia-fabricmanager nvidia-fabric-manager-devel
 }
 
 nscq_install() {
-  local nscq_package_name=libnvidia-nscq
-  dnf install -y ${nscq_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${nscq_package_name}
+  dnf install -y libnvidia-nscq-${DRIVER_VERSION}
+  dnf versionlock add libnvidia-nscq
 }
 
 # libnvsdm packages are not available for arm64
 nvsdm_install() {
-  local nvsdm_package_name=libnvsdm
   if [ "$TARGETARCH" = "amd64" ]; then
-    dnf install -y ${nvsdm_package_name}-${DRIVER_VERSION}
-    dnf versionlock add ${nvsdm_package_name}
+    dnf install -y libnvsdm-${DRIVER_VERSION}
+    dnf versionlock add libnvsdm
   fi
 }
 
@@ -177,9 +174,8 @@ nvlink5_pkgs_install() {
 }
 
 imex_install() {
-  local imex_package_name=nvidia-imex
-  dnf install -y ${imex_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${imex_package_name}
+  dnf install -y nvidia-imex-${DRIVER_VERSION}
+  dnf versionlock add nvidia-imex
 }
 
 extra_pkgs_install() {

--- a/rhel8/install.sh
+++ b/rhel8/install.sh
@@ -93,59 +93,29 @@ nvidia_installer () {
 }
 
 fabricmanager_install() {
-  local fabricmanager_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    fabricmanager_package_name=nvidia-fabricmanager
-  else
-    fabricmanager_package_name=nvidia-fabric-manager
-  fi
-  dnf install -y ${fabricmanager_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${fabricmanager_package_name}
+  dnf install -y nvidia-fabricmanager-${DRIVER_VERSION} nvidia-fabric-manager-devel-${DRIVER_VERSION}
+  dnf versionlock add nvidia-fabricmanager nvidia-fabric-manager-devel
 }
 
 nscq_install() {
-  local nscq_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    nscq_package_name=libnvidia-nscq
-  else
-    nscq_package_name=libnvidia-nscq-${DRIVER_BRANCH}
-  fi
-  dnf install -y ${nscq_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${nscq_package_name}
+  dnf install -y libnvidia-nscq-${DRIVER_VERSION}
+  dnf versionlock add libnvidia-nscq
 }
 
 nvsdm_install() {
-  local nvsdm_package_name
   if [ "$TARGETARCH" = "amd64" ]; then
-    if [ "$DRIVER_BRANCH" -ge "580" ]; then
-      nvsdm_package_name=libnvsdm
-    elif [ "$DRIVER_BRANCH" -ge "570" ]; then
-      nvsdm_package_name=libnvsdm-${DRIVER_BRANCH}
-    else
-      return 0
-    fi
-    dnf install -y ${nvsdm_package_name}-${DRIVER_VERSION}
-    dnf versionlock add ${nvsdm_package_name}
+    dnf install -y libnvsdm-${DRIVER_VERSION}
+    dnf versionlock add libnvsdm
   fi
 }
 
 nvlink5_pkgs_install() {
-  if [ "$DRIVER_BRANCH" -ge "550" ]; then
-    dnf install -y infiniband-diags nvlsm
-  fi
+  dnf install -y infiniband-diags nvlsm
 }
 
 imex_install() {
-  local imex_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    imex_package_name=nvidia-imex
-  elif [ "$DRIVER_BRANCH" -ge "550" ]; then
-    imex_package_name=nvidia-imex-${DRIVER_BRANCH}
-  else
-    return 0
-  fi
-  dnf install -y ${imex_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${imex_package_name}
+  dnf install -y nvidia-imex-${DRIVER_VERSION}
+  dnf versionlock add nvidia-imex
 }
 
 extra_pkgs_install() {

--- a/rhel9/install.sh
+++ b/rhel9/install.sh
@@ -99,60 +99,30 @@ nvidia_installer () {
 }
 
 fabricmanager_install() {
-  local fabricmanager_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    fabricmanager_package_name=nvidia-fabricmanager
-  else
-    fabricmanager_package_name=nvidia-fabric-manager
-  fi
-  dnf install -y ${fabricmanager_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${fabricmanager_package_name}
+  dnf install -y nvidia-fabricmanager-${DRIVER_VERSION} nvidia-fabric-manager-devel-${DRIVER_VERSION}
+  dnf versionlock add nvidia-fabricmanager nvidia-fabric-manager-devel
 }
 
 nscq_install() {
-  local nscq_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    nscq_package_name=libnvidia-nscq
-  else
-    nscq_package_name=libnvidia-nscq-${DRIVER_BRANCH}
-  fi
-  dnf install -y ${nscq_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${nscq_package_name}
+  dnf install -y libnvidia-nscq-${DRIVER_VERSION}
+  dnf versionlock add libnvidia-nscq
 }
 
 # libnvsdm packages are not available for arm64
 nvsdm_install() {
-  local nvsdm_package_name
   if [ "$TARGETARCH" = "amd64" ]; then
-    if [ "$DRIVER_BRANCH" -ge "580" ]; then
-      nvsdm_package_name=libnvsdm
-    elif [ "$DRIVER_BRANCH" -ge "570" ]; then
-      nvsdm_package_name=libnvsdm-${DRIVER_BRANCH}
-    else
-      return 0
-    fi
-    dnf install -y ${nvsdm_package_name}-${DRIVER_VERSION}
-    dnf versionlock add ${nvsdm_package_name}
+    dnf install -y libnvsdm-${DRIVER_VERSION}
+    dnf versionlock add libnvsdm
   fi
 }
 
 nvlink5_pkgs_install() {
-  if [ "$DRIVER_BRANCH" -ge "550" ]; then
-    dnf install -y infiniband-diags nvlsm
-  fi
+  dnf install -y infiniband-diags nvlsm
 }
 
 imex_install() {
-  local imex_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    imex_package_name=nvidia-imex
-  elif [ "$DRIVER_BRANCH" -ge "550" ]; then
-    imex_package_name=nvidia-imex-${DRIVER_BRANCH}
-  else
-    return 0
-  fi
-  dnf install -y ${imex_package_name}-${DRIVER_VERSION}
-  dnf versionlock add ${imex_package_name}
+  dnf install -y nvidia-imex-${DRIVER_VERSION}
+  dnf versionlock add nvidia-imex
 }
 extra_pkgs_install() {
   if [ "$DRIVER_TYPE" != "vgpu" ]; then

--- a/ubuntu22.04/install.sh
+++ b/ubuntu22.04/install.sh
@@ -45,60 +45,32 @@ setup_cuda_repo() {
 }
 
 fabricmanager_install() {
-  local fabricmanager_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    fabricmanager_package_name=nvidia-fabricmanager
-  else
-    fabricmanager_package_name=nvidia-fabricmanager-${DRIVER_BRANCH}
-  fi
-  apt-get install -y --no-install-recommends ${fabricmanager_package_name}=${DRIVER_VERSION}*
-  apt-mark hold ${fabricmanager_package_name}
+  apt-get install -y --no-install-recommends \
+      nvidia-fabricmanager=${DRIVER_VERSION}* \
+      nvidia-fabricmanager-dev=${DRIVER_VERSION}*
+  apt-mark hold nvidia-fabricmanager nvidia-fabricmanager-dev
 }
 
 nscq_install() {
-  local nscq_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    nscq_package_name=libnvidia-nscq
-  else
-    nscq_package_name=libnvidia-nscq-${DRIVER_BRANCH}
-  fi
-  apt-get install -y --no-install-recommends ${nscq_package_name}=${DRIVER_VERSION}*
-  apt-mark hold ${nscq_package_name}
+  apt-get install -y --no-install-recommends libnvidia-nscq=${DRIVER_VERSION}*
+  apt-mark hold libnvidia-nscq
 }
 
 # libnvsdm packages are not available for arm64
 nvsdm_install() {
-  local nvsdm_package_name
   if [ "$TARGETARCH" = "amd64" ]; then
-    if [ "$DRIVER_BRANCH" -ge "580" ]; then
-      nvsdm_package_name=libnvsdm
-    elif [ "$DRIVER_BRANCH" -ge "570" ]; then
-      nvsdm_package_name=libnvsdm-${DRIVER_BRANCH}
-    else
-      return 0
-    fi
-    apt-get install -y --no-install-recommends ${nvsdm_package_name}=${DRIVER_VERSION}*
-    apt-mark hold ${nvsdm_package_name}
+    apt-get install -y --no-install-recommends libnvsdm=${DRIVER_VERSION}*
+    apt-mark hold libnvsdm
   fi
 }
 
 nvlink5_pkgs_install() {
-  if [ "$DRIVER_BRANCH" -ge "570" ]; then
-    apt-get install -y --no-install-recommends nvlsm infiniband-diags
-  fi
+  apt-get install -y --no-install-recommends nvlsm infiniband-diags
 }
 
 imex_install() {
-  local imex_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    imex_package_name=nvidia-imex
-  elif [ "$DRIVER_BRANCH" -ge "550" ]; then
-    imex_package_name=nvidia-imex-${DRIVER_BRANCH}
-  else
-    return 0
-  fi
-  apt-get install -y --no-install-recommends ${imex_package_name}=${DRIVER_VERSION}*
-  apt-mark hold ${imex_package_name}
+  apt-get install -y --no-install-recommends nvidia-imex=${DRIVER_VERSION}*
+  apt-mark hold nvidia-imex
 }
 
 extra_pkgs_install() {

--- a/ubuntu24.04/install.sh
+++ b/ubuntu24.04/install.sh
@@ -45,60 +45,32 @@ setup_cuda_repo() {
 }
 
 fabricmanager_install() {
-  local fabricmanager_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    fabricmanager_package_name=nvidia-fabricmanager
-  else
-    fabricmanager_package_name=nvidia-fabricmanager-${DRIVER_BRANCH}
-  fi
-  apt-get install -y --no-install-recommends ${fabricmanager_package_name}=${DRIVER_VERSION}*
-  apt-mark hold ${fabricmanager_package_name}
+  apt-get install -y --no-install-recommends\
+      nvidia-fabricmanager=${DRIVER_VERSION}* \
+      nvidia-fabricmanager-dev=${DRIVER_VERSION}*
+  apt-mark hold nvidia-fabricmanager nvidia-fabricmanager-dev
 }
 
 nscq_install() {
-  local nscq_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    nscq_package_name=libnvidia-nscq
-  else
-    nscq_package_name=libnvidia-nscq-${DRIVER_BRANCH}
-  fi
-  apt-get install -y --no-install-recommends ${nscq_package_name}=${DRIVER_VERSION}*
-  apt-mark hold ${nscq_package_name}
+  apt-get install -y --no-install-recommends libnvidia-nscq=${DRIVER_VERSION}*
+  apt-mark hold libnvidia-nscq
 }
 
 # libnvsdm packages are not available for arm64
 nvsdm_install() {
-  local nvsdm_package_name
   if [ "$TARGETARCH" = "amd64" ]; then
-    if [ "$DRIVER_BRANCH" -ge "580" ]; then
-      nvsdm_package_name=libnvsdm
-    elif [ "$DRIVER_BRANCH" -ge "570" ]; then
-      nvsdm_package_name=libnvsdm-${DRIVER_BRANCH}
-    else
-      return 0
-    fi
-    apt-get install -y --no-install-recommends ${nvsdm_package_name}=${DRIVER_VERSION}*
-    apt-mark hold ${nvsdm_package_name}
+    apt-get install -y --no-install-recommends libnvsdm=${DRIVER_VERSION}*
+    apt-mark hold libnvsdm
   fi
 }
 
 nvlink5_pkgs_install() {
-  if [ "$DRIVER_BRANCH" -ge "570" ]; then
-    apt-get install -y --no-install-recommends nvlsm infiniband-diags
-  fi
+  apt-get install -y --no-install-recommends nvlsm infiniband-diags
 }
 
 imex_install() {
-  local imex_package_name
-  if [ "$DRIVER_BRANCH" -ge "580" ]; then
-    imex_package_name=nvidia-imex
-  elif [ "$DRIVER_BRANCH" -ge "550" ]; then
-    imex_package_name=nvidia-imex-${DRIVER_BRANCH}
-  else
-    return 0
-  fi
-  apt-get install -y --no-install-recommends ${imex_package_name}=${DRIVER_VERSION}*
-  apt-mark hold ${imex_package_name}
+  apt-get install -y --no-install-recommends nvidia-imex=${DRIVER_VERSION}*
+  apt-mark hold nvidia-imex
 }
 
 extra_pkgs_install() {

--- a/ubuntu26.04/install.sh
+++ b/ubuntu26.04/install.sh
@@ -69,6 +69,7 @@ extra_pkgs_install() {
     # to DRIVER_VERSION; nvlsm and infiniband-diags are versioned independently of the driver.
     apt-get install -y --no-install-recommends \
         nvidia-fabricmanager \
+        nvidia-fabricmanager-dev \
         libnvidia-nscq \
         nvidia-imex \
         nvlsm \


### PR DESCRIPTION
With this change, the driver container images will now download and save the fabricmanager-dev/devel packages during image build. This is needed by the DRA driver that performs dynamic fabric partitioning.

NOTE: At the time of filing this PR, the oldest supported driver branch is R580, so this PR limits the scope of the package install scripts to drivers starting from R580 and newer