### PR TITLE
[ubuntu22.04-24.04] pin nvidia-modprobe package version

### DIFF
--- a/ubuntu22.04/install.sh
+++ b/ubuntu22.04/install.sh
@@ -69,8 +69,8 @@ nvlink5_pkgs_install() {
 }
 
 imex_install() {
-  apt-get install -y --no-install-recommends nvidia-imex=${DRIVER_VERSION}*
-  apt-mark hold nvidia-imex
+  apt-get install -y --no-install-recommends nvidia-modprobe=${DRIVER_VERSION}* nvidia-imex=${DRIVER_VERSION}*
+  apt-mark hold nvidia-modprobe nvidia-imex
 }
 
 extra_pkgs_install() {

--- a/ubuntu24.04/install.sh
+++ b/ubuntu24.04/install.sh
@@ -69,8 +69,8 @@ nvlink5_pkgs_install() {
 }
 
 imex_install() {
-  apt-get install -y --no-install-recommends nvidia-imex=${DRIVER_VERSION}*
-  apt-mark hold nvidia-imex
+  apt-get install -y --no-install-recommends nvidia-modprobe=${DRIVER_VERSION}* nvidia-imex=${DRIVER_VERSION}*
+  apt-mark hold nvidia-modprobe nvidia-imex
 }
 
 extra_pkgs_install() {


### PR DESCRIPTION
`nvidia-modprobe` is a dependency for the `nvidia-imex` package. In Ubuntu 22.04 and Ubuntu 24.04, the `nvidia-modprobe` package that is implicitly pulled as a dependency does not have the same version as the `nvidia-imex` package. This does not seem to happen in `rhel`-based images.

NOTE: Ubuntu-26.04 uses the `driver-pinning-` metapackage which prevents issues like this. It may be worthwhile to explore this option in a follow-up.

The `dpkg -l` output currently looks like this:

```
# dpkg-query -l | grep -i nvidia
hi  libnvidia-nscq                   595.71.05-1ubuntu1                      amd64        NVSwitch Configuration and Query library
hi  nvidia-fabricmanager             595.71.05-1ubuntu1                      amd64        Fabric Manager for NVSwitch based systems
hi  nvidia-fabricmanager-dev         595.71.05-1ubuntu1                      amd64        Fabric Manager API headers and associated library
hi  nvidia-imex                      595.71.05-1ubuntu1                      amd64        IMEX Manager for NVIDIA based systems
ii  nvidia-modprobe                  610.57.04-1ubuntu1                      amd64        Load the NVIDIA kernel driver and create device files
```