### PR TITLE
[ci] add rhel9.8 and remove EOL'd rhcos versions

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -591,34 +591,6 @@ release:ngc-precompiled-ubuntu22.04:
   rules:
     - !reference [.precompiled-rules, rules]
 
-release:ngc-rhcos4.14:
-  extends:
-    - .release:ngc
-    - .dist-rhel9
-  variables:
-    OUT_DIST: "rhcos4.14"
-
-release:ngc-rhcos4.15:
-  extends:
-    - .release:ngc
-    - .dist-rhel9
-  variables:
-    OUT_DIST: "rhcos4.15"
-
-release:ngc-rhcos4.16:
-  extends:
-    - .release:ngc
-    - .dist-rhel9
-  variables:
-    OUT_DIST: "rhcos4.16"
-
-release:ngc-rhcos4.17:
-  extends:
-    - .release:ngc
-    - .dist-rhel9
-  variables:
-    OUT_DIST: "rhcos4.17"
-
 release:ngc-rhcos4.18:
   extends:
     - .release:ngc

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ OUT_IMAGE = $(OUT_IMAGE_NAME):$(OUT_IMAGE_TAG)
 
 ##### Public rules #####
 DISTRIBUTIONS := ubuntu22.04 ubuntu24.04 ubuntu26.04 signed_ubuntu22.04 signed_ubuntu24.04 signed_ubuntu26.04 rhel8 rhel9 rhel10 rocky8 rocky9 rocky10 precompiled_rhcos
-RHCOS_VERSIONS := rhcos4.14 rhcos4.15 rhcos4.16 rhcos4.17 rhcos4.18 rhel9.6
+RHCOS_VERSIONS := rhcos4.18 rhel9.6 rhel9.8
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))
 BASE_FROM := resolute noble jammy
 PUSH_TARGETS := $(patsubst %, push-%, $(DISTRIBUTIONS))


### PR DESCRIPTION
As of GPU Operator v26.3.x, the minimum OCP version is 4.18, so we remove the prior rhcos versions from CI manifest. This PR also adds `rhel9.8` as that is the corresponding RHEL version for OpenShift 4.22