### PR TITLE
fail fast when FabricManager fails to come up

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -773,13 +773,13 @@ _start_daemons() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/rhel10/precompiled/nvidia-driver
+++ b/rhel10/precompiled/nvidia-driver
@@ -268,12 +268,12 @@ _load_driver() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -750,13 +750,13 @@ _start_daemons() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/rhel8/precompiled/nvidia-driver
+++ b/rhel8/precompiled/nvidia-driver
@@ -210,7 +210,7 @@ _load_driver() {
 
     if _assert_nvswitch_system; then
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -769,13 +769,13 @@ _start_daemons() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/rhel9/precompiled/nvidia-driver
+++ b/rhel9/precompiled/nvidia-driver
@@ -294,12 +294,12 @@ _load_driver() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -377,9 +377,7 @@ _load_driver() {
         set +o xtrace -o nounset
     fi
 
-    _start_daemons
-
-    return 0
+    _start_daemons || return 1
 }
 
 # Stop persistenced and unload the kernel modules if they are currently loaded.
@@ -714,13 +712,13 @@ _start_daemons() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/ubuntu22.04/precompiled/nvidia-driver
+++ b/ubuntu22.04/precompiled/nvidia-driver
@@ -269,7 +269,7 @@ _load_driver() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
@@ -277,12 +277,10 @@ _load_driver() {
         fabricmanager_install
         nscq_install
         imex_install
- 
-        echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
-    fi
 
-    return 0
+        echo "Starting NVIDIA fabric manager daemon..."
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
+    fi
 }
 
 # Stop persistenced and unload the kernel modules if they are currently loaded.

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -318,9 +318,7 @@ _load_driver() {
         set +o xtrace -o nounset
     fi
 
-    _start_daemons
-
-    return 0
+    _start_daemons || return 1
 }
 
 # Stop persistenced and unload the kernel modules if they are currently loaded.
@@ -642,13 +640,13 @@ _start_daemons() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/ubuntu24.04/precompiled/nvidia-driver
+++ b/ubuntu24.04/precompiled/nvidia-driver
@@ -270,7 +270,7 @@ _load_driver() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
@@ -278,12 +278,10 @@ _load_driver() {
         fabricmanager_install
         nscq_install
         imex_install
- 
-        echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
-    fi
 
-    return 0
+        echo "Starting NVIDIA fabric manager daemon..."
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
+    fi
 }
 
 # Stop persistenced and unload the kernel modules if they are currently loaded.

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -330,9 +330,7 @@ _load_driver() {
         set +o xtrace -o nounset
     fi
 
-    _start_daemons
-
-    return 0
+    _start_daemons || return 1
 }
 
 # Stop persistenced and unload the kernel modules if they are currently loaded.
@@ -702,13 +700,13 @@ _start_daemons() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
         _configure_fabric_manager
         echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
 }
 

--- a/ubuntu26.04/precompiled/nvidia-driver
+++ b/ubuntu26.04/precompiled/nvidia-driver
@@ -240,7 +240,7 @@ _load_driver() {
                                                --fm-config-file $fm_config_file \
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
-                                               --nvlsm-pid-file $nvlsm_pid_file
+                                               --nvlsm-pid-file $nvlsm_pid_file || return 1
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then
@@ -248,12 +248,10 @@ _load_driver() {
         fabricmanager_install
         nscq_install
         imex_install
- 
-        echo "Starting NVIDIA fabric manager daemon..."
-        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
-    fi
 
-    return 0
+        echo "Starting NVIDIA fabric manager daemon..."
+        nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
+    fi
 }
 
 # Stop persistenced and unload the kernel modules if they are currently loaded.


### PR DESCRIPTION
Today, the driver containers go into `Running` mode even if Fabric Manager doesn't come up successfully. Given that Fabric Manager is a must-have for GPUs to be usable in NVSwitch-based nodes, the driver container should fail fast instead. This would make it easier for users to debug any driver container issues relating to Fabric Manager as they get immediate feedback 