### PR TITLE
[B200+][NVLink5+] reset GPUs after FABRIC_MODE=1 is set

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -774,6 +774,12 @@ _start_daemons() {
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
                                                --nvlsm-pid-file $nvlsm_pid_file || return 1
+        if [ ! -z "${NVFM_CONFIG_FABRIC_MODE:-}" ] && [ "${NVFM_CONFIG_FABRIC_MODE}" == "1" ]; then
+            # We reset the GPU devices after Fabric Manager startup to clear stale FM
+            # partition data after setting FABRIC_MODE=1
+            echo "Resetting GPUs to clear stale fabric partition states..."
+            nvidia-smi -r
+        fi
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -751,6 +751,12 @@ _start_daemons() {
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
                                                --nvlsm-pid-file $nvlsm_pid_file || return 1
+        if [ ! -z "${NVFM_CONFIG_FABRIC_MODE:-}" ] && [ "${NVFM_CONFIG_FABRIC_MODE}" == "1" ]; then
+            # We reset the GPU devices after Fabric Manager startup to clear stale FM
+            # partition data after setting FABRIC_MODE=1
+            echo "Resetting GPUs to clear stale fabric partition states..."
+            nvidia-smi -r
+        fi
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -770,6 +770,12 @@ _start_daemons() {
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
                                                --nvlsm-pid-file $nvlsm_pid_file || return 1
+        if [ ! -z "${NVFM_CONFIG_FABRIC_MODE:-}" ] && [ "${NVFM_CONFIG_FABRIC_MODE}" == "1" ]; then
+            # We reset the GPU devices after Fabric Manager startup to clear stale FM
+            # partition data after setting FABRIC_MODE=1
+            echo "Resetting GPUs to clear stale fabric partition states..."
+            nvidia-smi -r
+        fi
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -713,6 +713,12 @@ _start_daemons() {
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
                                                --nvlsm-pid-file $nvlsm_pid_file || return 1
+        if [ ! -z "${NVFM_CONFIG_FABRIC_MODE:-}" ] && [ "${NVFM_CONFIG_FABRIC_MODE}" == "1" ]; then
+            # We reset the GPU devices after Fabric Manager startup to clear stale FM
+            # partition data after setting FABRIC_MODE=1
+            echo "Resetting GPUs to clear stale fabric partition states..."
+            nvidia-smi -r
+        fi
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -641,6 +641,12 @@ _start_daemons() {
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
                                                --nvlsm-pid-file $nvlsm_pid_file || return 1
+        if [ ! -z "${NVFM_CONFIG_FABRIC_MODE:-}" ] && [ "${NVFM_CONFIG_FABRIC_MODE}" == "1" ]; then
+            # We reset the GPU devices after Fabric Manager startup to clear stale FM
+            # partition data after setting FABRIC_MODE=1
+            echo "Resetting GPUs to clear stale fabric partition states..."
+            nvidia-smi -r
+        fi
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -701,6 +701,12 @@ _start_daemons() {
                                                --fm-pid-file $fm_pid_file \
                                                --nvlsm-config-file $nvlsm_config_file \
                                                --nvlsm-pid-file $nvlsm_pid_file || return 1
+        if [ ! -z "${NVFM_CONFIG_FABRIC_MODE:-}" ] && [ "${NVFM_CONFIG_FABRIC_MODE}" == "1" ]; then
+            # We reset the GPU devices after Fabric Manager startup to clear stale FM
+            # partition data after setting FABRIC_MODE=1
+            echo "Resetting GPUs to clear stale fabric partition states..."
+            nvidia-smi -r
+        fi
 
     # If not a NVLink5+ switch, check for the presence of NVLink4 (or below) switches
     elif _assert_nvswitch_system; then


### PR DESCRIPTION
NVLinked systems that use NVLink generation 5 or greater require the GPUs to be reset after Fabric Manager is started up with `FABRIC_MODE=1` set in its config.