### PR TITLE
add new status file to signal daemons startup

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -95,6 +95,11 @@ _resolve_kernel_version() {
     return 0
 }
 
+_set_daemons_status() {
+    mkdir -p /run/nvidia/validations
+    echo "${1}" > /run/nvidia/validations/.driver-daemons-status
+}
+
 # Install the kernel modules header/builtin/order files and generate the kernel version string.
 _install_prerequisites() (
     local tmp_dir=$(mktemp -d)
@@ -787,6 +792,7 @@ _start_daemons() {
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
+    _set_daemons_status "Ready"
 }
 
 _store_driver_digest() {
@@ -877,6 +883,7 @@ _load() {
 }
 
 init() {
+    _set_daemons_status "NotReady"
     _prepare_exclusive
 
     if _should_skip_kernel_module_reload; then

--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -93,6 +93,11 @@ _resolve_kernel_version() {
     return 0
 }
 
+_set_daemons_status() {
+    mkdir -p /run/nvidia/validations
+    echo "${1}" > /run/nvidia/validations/.driver-daemons-status
+}
+
 # Install the kernel modules header/builtin/order files and generate the kernel version string.
 _install_prerequisites() (
     local tmp_dir=$(mktemp -d)
@@ -393,7 +398,6 @@ _load_driver() {
 
     echo "Loading ipmi and i2c_core kernel modules..."
     modprobe -a i2c_core ipmi_msghandler ipmi_devintf
-
     echo "Loading NVIDIA driver kernel modules..."
     set -o xtrace +o nounset
     modprobe nvidia
@@ -764,6 +768,7 @@ _start_daemons() {
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
+    _set_daemons_status "Ready"
 }
 
 _store_driver_digest() {
@@ -854,6 +859,7 @@ _load() {
 }
 
 init() {
+    _set_daemons_status "NotReady"
     _prepare_exclusive
 
     if _should_skip_kernel_module_reload; then

--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -95,6 +95,11 @@ _resolve_kernel_version() {
     return 0
 }
 
+_set_daemons_status() {
+    mkdir -p /run/nvidia/validations
+    echo "${1}" > /run/nvidia/validations/.driver-daemons-status
+}
+
 # Install the kernel modules header/builtin/order files and generate the kernel version string.
 _install_prerequisites() (
     local tmp_dir=$(mktemp -d)
@@ -783,6 +788,7 @@ _start_daemons() {
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
+    _set_daemons_status "Ready"
 }
 
 _store_driver_digest() {
@@ -873,6 +879,7 @@ _load() {
 }
 
 init() {
+    _set_daemons_status "NotReady"
     _prepare_exclusive
 
     if _should_skip_kernel_module_reload; then

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -87,6 +87,11 @@ _resolve_kernel_version() {
     return 0
 }
 
+_set_daemons_status() {
+    mkdir -p /run/nvidia/validations
+    echo "${1}" > /run/nvidia/validations/.driver-daemons-status
+}
+
 # Install the kernel modules header/builtin/order files and generate the kernel version string.
 _install_prerequisites() (
     local tmp_dir=$(mktemp -d)
@@ -362,7 +367,6 @@ _load_driver() {
 
     echo "Loading ipmi and i2c_core kernel modules..."
     modprobe -a i2c_core ipmi_msghandler ipmi_devintf
-
     echo "Loading NVIDIA driver kernel modules..."
     set -o xtrace +o nounset
     modprobe nvidia
@@ -726,6 +730,7 @@ _start_daemons() {
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
+    _set_daemons_status "Ready"
 }
 
 # Check if fast path should be used (driver already loaded with matching config)
@@ -799,6 +804,8 @@ init() {
 
     trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
     trap "_shutdown" EXIT
+
+    _set_daemons_status "NotReady"
 
     if _should_skip_kernel_module_reload; then
         echo "The NVIDIA driver is already loaded with the desired configuration, performing userspace-only install"

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -97,6 +97,11 @@ _resolve_kernel_version() {
     return 0
 }
 
+_set_daemons_status() {
+    mkdir -p /run/nvidia/validations
+    echo "${1}" > /run/nvidia/validations/.driver-daemons-status
+}
+
 # Install the kernel modules header/builtin/order files and generate the kernel version string.
 _install_prerequisites() (
     local tmp_dir=$(mktemp -d)
@@ -303,7 +308,6 @@ _load_driver() {
 
     echo "Loading ipmi and i2c_core kernel modules..."
     modprobe -a i2c_core ipmi_msghandler ipmi_devintf
-
     echo "Loading NVIDIA driver kernel modules..."
     set -o xtrace +o nounset
     modprobe nvidia
@@ -654,6 +658,7 @@ _start_daemons() {
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
+    _set_daemons_status "Ready"
 }
 
 # Check if fast path should be used (driver already loaded with matching config)
@@ -750,6 +755,8 @@ init() {
 
     trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
     trap "_shutdown" EXIT
+
+    _set_daemons_status "NotReady"
 
     if _should_skip_kernel_module_reload; then
         echo "The NVIDIA driver is already loaded with the desired configuration, performing userspace-only install"

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -107,6 +107,11 @@ _resolve_kernel_version() {
     return 0
 }
 
+_set_daemons_status() {
+    mkdir -p /run/nvidia/validations
+    echo "${1}" > /run/nvidia/validations/.driver-daemons-status
+}
+
 # Install the kernel modules header/builtin/order files and generate the kernel version string.
 _install_prerequisites() (
     local tmp_dir=$(mktemp -d)
@@ -315,7 +320,6 @@ _load_driver() {
 
     echo "Loading ipmi and i2c_core kernel modules..."
     modprobe -a i2c_core ipmi_msghandler ipmi_devintf
-
     echo "Loading NVIDIA driver kernel modules..."
     set -o xtrace +o nounset
     modprobe nvidia
@@ -714,6 +718,7 @@ _start_daemons() {
         echo "Starting NVIDIA fabric manager daemon..."
         nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg || return 1
     fi
+    _set_daemons_status "Ready"
 }
 
 # Check if fast path should be used (driver already loaded with matching config)
@@ -844,6 +849,8 @@ init() {
 
     trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
     trap "_shutdown" EXIT
+
+    _set_daemons_status "NotReady"
 
     if _should_skip_kernel_module_reload; then
         echo "The NVIDIA driver is already loaded with the desired configuration, performing userspace-only install"


### PR DESCRIPTION
This PR introduces a new status file called `/run/nvidia/validations/.driver-daemons-status`. This file can be leveraged by components downstream who need to ensure that the driver daemons like persistenced, fabricmanager, vgpu-topologyd have come up before performing any other operations