### PR TITLE
fix: init getopt rejects -k/--kernel and -t/--tag options

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -941,7 +941,7 @@ usage() {
 Usage: $0 COMMAND [ARG...]
 
 Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS] [-k | --kernel KERNEL_VERSION] [-t | --tag PACKAGE_TAG]
 EOF
     exit 1
 }
@@ -951,7 +951,7 @@ if [ $# -eq 0 ]; then
 fi
 command=$1; shift
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: init getopt rejects -k/--kernel and -t/--tag options.

## Changes
- `ubuntu26.04/nvidia-driver`: init getopt rejects -k/--kernel and -t/--tag options.

## Details
```diff
--- ubuntu26.04/nvidia-driver
+++ ubuntu26.04/nvidia-driver
@@ -847,9 +847,9 @@
 usage() {
     cat >&2 <<EOF
 Usage: $0 COMMAND [ARG...]
 
 Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS] [-k | --kernel KERNEL_VERSION] [-t | --tag PACKAGE_TAG]
 EOF
     exit 1
 }
@@ -856,6 +856,6 @@
 if [ $# -eq 0 ]; then
     usage
 fi
 command=$1; shift
 case "${command}" in
-init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
```

## Tests
- `tests/test_init_getopt_options.sh`

```diff
--- /dev/null
+++ tests/test_init_getopt_options.sh
@@ -0,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! grep -q 'init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@")' ubuntu26.04/nvidia-driver; then
+    echo "FAIL: init getopt does not accept --kernel/--tag" >&2
+    exit 1
+fi
+if ! grep -F '[-k | --kernel KERNEL_VERSION] [-t | --tag PACKAGE_TAG]' ubuntu26.04/nvidia-driver; then
+    echo "FAIL: usage text does not document -k/--kernel and -t/--tag" >&2
+    exit 1
+fi
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).