### PR TITLE
fix: replace [ ! -z ] with [ -n ] in _update_ca_certificates

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -75,7 +75,7 @@ _update_local_repo_lists() {
 }
 
 _update_ca_certificates() {
-    if [ ! -z "$(ls -A /usr/local/share/ca-certificates)" ]; then
+    if [ -n "$(ls -A /usr/local/share/ca-certificates)" ]; then
         update-ca-certificates
     fi
 }


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: replace [ ! -z ] with [ -n ] in _update_ca_certificates.

## Changes
- `ubuntu26.04/nvidia-driver`: replace [ ! -z ] with [ -n ] in _update_ca_certificates.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,1 +1,1 @@
-    if [ ! -z "$(ls -A /usr/local/share/ca-certificates)" ]; then
+    if [ -n "$(ls -A /usr/local/share/ca-certificates)" ]; then
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).