### PR TITLE
fix: fallback uses DRIVER_BRANCH which is never set

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -780,7 +780,8 @@ _resolve_kernel_type() {
 }
 
 _resolve_kernel_type_from_driver_branch() {
-  [[ "${DRIVER_BRANCH}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
+  local driver_branch="${DRIVER_BRANCH:-${DRIVER_VERSION%%.*}}"
+  [[ "${driver_branch}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
 }
 
 _move_kernel_module_sources() {


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: fallback uses DRIVER_BRANCH which is never set.

## Changes
- `ubuntu26.04/nvidia-driver`: fallback uses DRIVER_BRANCH which is never set.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,3 +1,4 @@
-_resolve_kernel_type_from_driver_branch() {
-  [[ "${DRIVER_BRANCH}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
-}
+_resolve_kernel_type_from_driver_branch() {
+  local driver_branch="${DRIVER_BRANCH:-${DRIVER_VERSION%%.*}}"
+  [[ "${driver_branch}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
+}
```

## Tests
- `tests/test_driver_branch_fallback.sh`

```diff
diff --git a/tests/test_driver_branch_fallback.sh b/tests/test_driver_branch_fallback.sh
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test_driver_branch_fallback.sh
@@ -0,0 +1,21 @@
+#!/bin/bash
+# Regression test: _resolve_kernel_type_from_driver_branch must not rely on an
+# unset DRIVER_BRANCH variable.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../ubuntu26.04/nvidia-driver"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+test_driver_branch_fallback_is_guarded() {
+    local body
+    body=$(sed -n '/^_resolve_kernel_type_from_driver_branch() {/,/^}$/p' "$SCRIPT")
+    [ -n "$body" ] || fail "could not extract fallback function"
+    grep -F '${DRIVER_BRANCH:-' <<<"$body" >/dev/null \
+        || fail "DRIVER_BRANCH is used without a default"
+}
+
+test_driver_branch_fallback_is_guarded
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).