### PR TITLE
fix: _resolve_kernel_type calls nvidia-installer without path

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -766,7 +766,7 @@ _resolve_kernel_type() {
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
     KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
+    kernel_module_type=$(./nvidia-installer --print-recommended-kernel-module-type)
     if [ $? -ne 0 ]; then
       echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
       _resolve_kernel_type_from_driver_branch


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: _resolve_kernel_type calls nvidia-installer without path.

## Changes
- `ubuntu26.04/nvidia-driver`: _resolve_kernel_type calls nvidia-installer without path.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,1 +1,1 @@
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
+    kernel_module_type=$(./nvidia-installer --print-recommended-kernel-module-type)
```

## Tests
- `tests/test_nvidia_installer_path.sh`

```diff
diff --git a/tests/test_nvidia_installer_path.sh b/tests/test_nvidia_installer_path.sh
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test_nvidia_installer_path.sh
@@ -0,0 +1,21 @@
+#!/bin/bash
+# Regression test: _resolve_kernel_type must invoke the local nvidia-installer.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../ubuntu26.04/nvidia-driver"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+test_resolve_kernel_type_uses_local_installer() {
+    local body
+    body=$(sed -n '/^_resolve_kernel_type() {/,/^}$/p' "$SCRIPT")
+    [ -n "$body" ] || fail "could not extract _resolve_kernel_type"
+    grep -F './nvidia-installer --print-recommended-kernel-module-type' <<<"$body" >/dev/null \
+        || fail "not invoking local ./nvidia-installer"
+}
+
+test_resolve_kernel_type_uses_local_installer
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).