### PR TITLE
fix: init option parsing ignores -k/-t and uses unquoted options

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -951,7 +951,7 @@ if [ $# -eq 0 ]; then
 fi
 command=$1; shift
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;
@@ -966,13 +966,14 @@ MAX_THREADS=""
 KERNEL_VERSION=$(uname -r)
 PACKAGE_TAG=""
 
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift ;;
     -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
     -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
     -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
     --) shift; break ;;
+    *) usage ;;
     esac
 done
 if [ $# -ne 0 ]; then


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: init option parsing ignores -k/-t and uses unquoted options.

## Changes
- `ubuntu26.04/nvidia-driver`: init option parsing ignores -k/-t and uses unquoted options.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,25 +1,26 @@
-case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
-    reload_nvidia_peermem) options="" ;;
-    probe_nvidia_peermem) options="" ;;
-    *) usage ;;
-esac
-if [ $? -ne 0 ]; then
-    usage
-fi
-eval set -- "${options}"
-
-ACCEPT_LICENSE=""
-MAX_THREADS=""
-KERNEL_VERSION=$(uname -r)
-PACKAGE_TAG=""
-
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
-    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
-    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
-    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
-    --) shift; break ;;
-    esac
-done
+case "${command}" in
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
+    reload_nvidia_peermem) options="" ;;
+    probe_nvidia_peermem) options="" ;;
+    *) usage ;;
+esac
+if [ $? -ne 0 ]; then
+    usage
+fi
+eval set -- "${options}"
+
+ACCEPT_LICENSE=""
+MAX_THREADS=""
+KERNEL_VERSION=$(uname -r)
+PACKAGE_TAG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift ;;
+    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
+    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
+    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+    --) shift; break ;;
+    *) usage ;;
+    esac
+done
```

## Tests
- `tests/test_option_parsing.sh`

```diff
diff --git a/tests/test_option_parsing.sh b/tests/test_option_parsing.sh
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test_option_parsing.sh
@@ -0,0 +1,27 @@
+#!/bin/bash
+# Minimal regression tests for the option parsing in ubuntu26.04/nvidia-driver.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../ubuntu26.04/nvidia-driver"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+test_init_getopt_accepts_kernel_and_tag() {
+    local line
+    line=$(grep -E 'init\) options=\$\(getopt' "$SCRIPT") || fail "could not find init getopt line"
+    [[ "$line" == *"kernel:"* ]] || fail "getopt missing --kernel"
+    [[ "$line" == *"tag:"* ]] || fail "getopt missing --tag"
+    [[ "$line" == *"k:"* ]] || fail "getopt missing -k"
+    [[ "$line" == *"t:"* ]] || fail "getopt missing -t"
+}
+
+test_loop_uses_positional_params() {
+    grep -F 'for opt in ${options}' "$SCRIPT" >/dev/null && fail "still iterating the raw options string"
+    grep -F 'while [ $# -gt 0 ]' "$SCRIPT" >/dev/null || fail "option loop does not consume positional parameters"
+}
+
+test_init_getopt_accepts_kernel_and_tag
+test_loop_uses_positional_params
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).