### PR TITLE
fix: option loop iterates over raw getopt string

### DIFF
--- a/tests/test_option_loop.sh
+++ b/tests/test_option_loop.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+driver_script="ubuntu26.04/nvidia-driver"
+
+awk '/^eval set --/,/^done/' "$driver_script" > /tmp/option_parser.txt
+
+if grep -q 'for opt in \${options}' /tmp/option_parser.txt; then
+    echo "FAIL: option parser iterates over the raw getopt string" >&2
+    exit 1
+fi
+
+if ! grep -q 'while true; do' /tmp/option_parser.txt; then
+    echo "FAIL: option parser does not use a positional-parameter loop" >&2
+    exit 1
+fi

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -966,13 +966,14 @@ MAX_THREADS=""
 KERNEL_VERSION=$(uname -r)
 PACKAGE_TAG=""
 
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
-    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
-    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
-    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+while true; do
+    case "$1" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift ;;
+    -k | --kernel) KERNEL_VERSION="$2"; shift 2 ;;
+    -m | --max-threads) MAX_THREADS="$2"; shift 2 ;;
+    -t | --tag) PACKAGE_TAG="$2"; shift 2 ;;
     --) shift; break ;;
+    *) usage ;;
     esac
 done
 if [ $# -ne 0 ]; then


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: option loop iterates over raw getopt string.

## Changes
- `ubuntu26.04/nvidia-driver`: option loop iterates over raw getopt string.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,9 +1,10 @@
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
-    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
-    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
-    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
-    --) shift; break ;;
-    esac
-done
+while true; do
+    case "$1" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift ;;
+    -k | --kernel) KERNEL_VERSION="$2"; shift 2 ;;
+    -m | --max-threads) MAX_THREADS="$2"; shift 2 ;;
+    -t | --tag) PACKAGE_TAG="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) usage ;;
+    esac
+done
```

## Tests
- `tests/test_option_loop.sh`

```diff
--- /dev/null
+++ b/tests/test_option_loop.sh
@@ -0,0 +1,16 @@
+#!/bin/bash
+set -e
+
+driver_script="ubuntu26.04/nvidia-driver"
+
+awk '/^eval set --/,/^done/' "$driver_script" > /tmp/option_parser.txt
+
+if grep -q 'for opt in \${options}' /tmp/option_parser.txt; then
+    echo "FAIL: option parser iterates over the raw getopt string" >&2
+    exit 1
+fi
+
+if ! grep -q 'while true; do' /tmp/option_parser.txt; then
+    echo "FAIL: option parser does not use a positional-parameter loop" >&2
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).