### PR TITLE
fix: reload_nvidia_peermem trap placed after blocking sleep

### DIFF
--- a/tests/test_peermem_trap.sh
+++ b/tests/test_peermem_trap.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+driver_script="ubuntu26.04/nvidia-driver"
+
+awk '/^reload_nvidia_peermem\(\)/,/^}/' "$driver_script" > /tmp/reload_func.txt
+
+trap_line=$(grep -n '^[[:space:]]*trap' /tmp/reload_func.txt | head -1 | cut -d: -f1 || true)
+sleep_line=$(grep -n '^[[:space:]]*sleep inf' /tmp/reload_func.txt | head -1 | cut -d: -f1 || true)
+
+if [ -z "$trap_line" ] || [ -z "$sleep_line" ]; then
+    echo "FAIL: could not locate trap and/or sleep inf lines" >&2
+    exit 1
+fi
+
+if [ "$trap_line" -gt "$sleep_line" ]; then
+    echo "FAIL: trap is installed after the first blocking sleep" >&2
+    exit 1
+fi
+
+echo "PASS"

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -906,17 +906,19 @@ reload_nvidia_peermem() {
     fi
     # get any parameters provided for nvidia-peermem
     _get_module_params && set +o nounset
+
+    # Set up signal handling before any potentially blocking sleep.
+    trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+
     # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
     if [ -f /sys/module/nvidia_peermem/refcnt ]; then
         echo "nvidia-peermem module already loaded, skipping modprobe"
         sleep inf
-        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
     fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"
             sleep inf
-            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
         fi
     fi
     echo "failed to load nvidia-peermem module"


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: reload_nvidia_peermem trap placed after blocking sleep.

## Changes
- `ubuntu26.04/nvidia-driver`: reload_nvidia_peermem trap placed after blocking sleep.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,33 +1,35 @@
-reload_nvidia_peermem() {
-    if [ "$USE_HOST_MOFED" = "true" ]; then
-        until  lsmod | grep mlx5_core > /dev/null 2>&1 && [ -f /run/nvidia/validations/.driver-ctr-ready ];
-        do
-            echo "waiting for mellanox ofed and nvidia drivers to be installed"
-            sleep 10
-        done
-    else
-        # use driver readiness flag created by MOFED container
-        until  [ -f /run/mellanox/drivers/.driver-ready ] && [ -f /run/nvidia/validations/.driver-ctr-ready ];
-        do
-            echo "waiting for mellanox ofed and nvidia drivers to be installed"
-            sleep 10
-        done
-    fi
-    # get any parameters provided for nvidia-peermem
-    _get_module_params && set +o nounset
-    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
-    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-        echo "nvidia-peermem module already loaded, skipping modprobe"
-        sleep inf
-        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-    fi
-    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
-        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-            echo "successfully loaded nvidia-peermem module, now waiting for signal"
-            sleep inf
-            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-        fi
-    fi
-    echo "failed to load nvidia-peermem module"
-    exit 1
-}
+reload_nvidia_peermem() {
+    if [ "$USE_HOST_MOFED" = "true" ]; then
+        until  lsmod | grep mlx5_core > /dev/null 2>&1 && [ -f /run/nvidia/validations/.driver-ctr-ready ];
+        do
+            echo "waiting for mellanox ofed and nvidia drivers to be installed"
+            sleep 10
+        done
+    else
+        # use driver readiness flag created by MOFED container
+        until  [ -f /run/mellanox/drivers/.driver-ready ] && [ -f /run/nvidia/validations/.driver-ctr-ready ];
+        do
+            echo "waiting for mellanox ofed and nvidia drivers to be installed"
+            sleep 10
+        done
+    fi
+    # get any parameters provided for nvidia-peermem
+    _get_module_params && set +o nounset
+
+    # Set up signal handling before any potentially blocking sleep.
+    trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        sleep inf
+    fi
+    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
+        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+            echo "successfully loaded nvidia-peermem module, now waiting for signal"
+            sleep inf
+        fi
+    fi
+    echo "failed to load nvidia-peermem module"
+    exit 1
+}
```

## Tests
- `tests/test_peermem_trap.sh`

```diff
--- /dev/null
+++ b/tests/test_peermem_trap.sh
@@ -0,0 +1,21 @@
+#!/bin/bash
+set -e
+
+driver_script="ubuntu26.04/nvidia-driver"
+
+awk '/^reload_nvidia_peermem\(\)/,/^}/' "$driver_script" > /tmp/reload_func.txt
+
+trap_line=$(grep -n '^[[:space:]]*trap' /tmp/reload_func.txt | head -1 | cut -d: -f1 || true)
+sleep_line=$(grep -n '^[[:space:]]*sleep inf' /tmp/reload_func.txt | head -1 | cut -d: -f1 || true)
+
+if [ -z "$trap_line" ] || [ -z "$sleep_line" ]; then
+    echo "FAIL: could not locate trap and/or sleep inf lines" >&2
+    exit 1
+fi
+
+if [ "$trap_line" -gt "$sleep_line" ]; then
+    echo "FAIL: trap is installed after the first blocking sleep" >&2
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).