### PR TITLE
fix: init opens PID file before ensuring RUN_DIR exists

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -840,6 +840,7 @@ init() {
     echo -e "Starting installation of NVIDIA driver version ${DRIVER_VERSION} for Linux kernel version ${KERNEL_VERSION}"
     echo -e "Kernel module type: ${KERNEL_MODULE_TYPE}\n"
 
+    mkdir -p ${RUN_DIR}
     exec 3> ${PID_FILE}
     if ! flock -n 3; then
         echo "An instance of the NVIDIA driver is already running, aborting"


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: init opens PID file before ensuring RUN_DIR exists.

## Changes
- `ubuntu26.04/nvidia-driver`: init opens PID file before ensuring RUN_DIR exists.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,2 +1,3 @@
-    exec 3> ${PID_FILE}
-    if ! flock -n 3; then
+    mkdir -p ${RUN_DIR}
+    exec 3> ${PID_FILE}
+    if ! flock -n 3; then
```

## Tests
- `tests/test_init_rundir.sh`

```diff
--- /dev/null
+++ b/tests/test_init_rundir.sh
@@ -0,0 +1,22 @@
+#!/bin/bash
+set -e
+
+driver_script="ubuntu26.04/nvidia-driver"
+
+awk '/^init\(\)/,/^}/' "$driver_script" > /tmp/init_func.txt
+
+mkdir_line=$(grep -n '^[[:space:]]*mkdir -p \${RUN_DIR}' /tmp/init_func.txt | head -1 | cut -d: -f1 || true)
+exec_line=$(grep -n '^[[:space:]]*exec 3> \${PID_FILE}' /tmp/init_func.txt | head -1 | cut -d: -f1 || true)
+
+if [ -z "$mkdir_line" ]; then
+    echo "FAIL: init does not create \${RUN_DIR} before opening PID file" >&2
+    exit 1
+fi
+
+if [ "$mkdir_line" -gt "$exec_line" ]; then
+    echo "FAIL: mkdir -p \${RUN_DIR} must come before exec 3> \${PID_FILE}" >&2
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).