### PR TITLE
fix: vgpu runfile installer uses relative path in wrong cwd

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -537,6 +537,7 @@ _install_driver_runfile() {
     install_args+=("--skip-module-load")
 
     # Install the NVIDIA driver in one step
+    cd /drivers
     sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
                     --ui=none \
                     --no-drm \


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: vgpu runfile installer uses relative path in wrong cwd.

## Changes
- `ubuntu26.04/nvidia-driver`: vgpu runfile installer uses relative path in wrong cwd.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,2 +1,3 @@
-    # Install the NVIDIA driver in one step
-    sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
+    # Install the NVIDIA driver in one step
+    cd /drivers
+    sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).