### PR TITLE
fix: peermem reloader installs signal trap after sleep

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -909,14 +909,14 @@ reload_nvidia_peermem() {
     # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
     if [ -f /sys/module/nvidia_peermem/refcnt ]; then
         echo "nvidia-peermem module already loaded, skipping modprobe"
-        sleep inf
         trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+        sleep inf
     fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"
-            sleep inf
             trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+            sleep inf
         fi
     fi
     echo "failed to load nvidia-peermem module"


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: peermem reloader installs signal trap after sleep.

## Changes
- `ubuntu26.04/nvidia-driver`: peermem reloader installs signal trap after sleep.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,13 +1,13 @@
-    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
-    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-        echo "nvidia-peermem module already loaded, skipping modprobe"
-        sleep inf
-        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-    fi
-    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
-        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-            echo "successfully loaded nvidia-peermem module, now waiting for signal"
-            sleep inf
-            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-        fi
-    fi
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+        sleep inf
+    fi
+    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
+        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+            echo "successfully loaded nvidia-peermem module, now waiting for signal"
+            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+            sleep inf
+        fi
+    fi
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).