### PR TITLE
fix: guard mellanox device scan against missing PCI entries

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -205,11 +205,11 @@ _ensure_nvlink5_prerequisites() (
 
 # Check if mellanox devices are present
 _mellanox_devices_present() {
-    devices_found=0
     for dev in /sys/bus/pci/devices/*; do
-        read vendor < $dev/vendor
+        [ -e "$dev" ] || continue
+        read vendor < "$dev/vendor"
         if [ "$vendor" = "0x15b3" ]; then
-            echo "Mellanox device found at $(basename $dev)"
+            echo "Mellanox device found at $(basename "$dev")"
             return 0
         fi
     done


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: guard mellanox device scan against missing PCI entries.

## Changes
- `ubuntu26.04/nvidia-driver`: guard mellanox device scan against missing PCI entries.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,12 +1,12 @@
-_mellanox_devices_present() {
-    devices_found=0
-    for dev in /sys/bus/pci/devices/*; do
-        read vendor < $dev/vendor
-        if [ "$vendor" = "0x15b3" ]; then
-            echo "Mellanox device found at $(basename $dev)"
-            return 0
-        fi
-    done
-    echo "No Mellanox devices were found..."
-    return 1
-}
+_mellanox_devices_present() {
+    for dev in /sys/bus/pci/devices/*; do
+        [ -e "$dev" ] || continue
+        read vendor < "$dev/vendor"
+        if [ "$vendor" = "0x15b3" ]; then
+            echo "Mellanox device found at $(basename "$dev")"
+            return 0
+        fi
+    done
+    echo "No Mellanox devices were found..."
+    return 1
+}
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).