### PR TITLE
fix: init getopt omits -k/--kernel and -t/--tag options

### DIFF
--- a/tests/test_init_options.bash
+++ b/tests/test_init_options.bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Regression test: init getopt must accept the options the parser consumes.
+set -euo pipefail
+
+driver="$(cd "$(dirname "$0")" && pwd)/../ubuntu26.04/nvidia-driver"
+[ -f "$driver" ] || { echo "driver script not found"; exit 1; }
+
+grep -F -q -- '-o am:k:t:' "$driver" || {
+    echo 'FAIL: init getopt short options do not include -k/-t'
+    exit 1
+}
+grep -F -q -- '-l accept-license,max-threads:,kernel:,tag:' "$driver" || {
+    echo 'FAIL: init getopt long options do not include --kernel/--tag'
+    exit 1
+}
+grep -F -q -- '[-k | --kernel KERNEL_VERSION]' "$driver" || {
+    echo 'FAIL: usage does not document --kernel'
+    exit 1
+}
+grep -F -q -- '[-t | --tag PACKAGE_TAG]' "$driver" || {
+    echo 'FAIL: usage does not document --tag'
+    exit 1
+}
+if grep -F -A3 'probe_nvidia_peermem) options="" ;;' "$driver" | grep -F -q 'if [ $? -ne 0 ]; then'; then
+    echo 'FAIL: post-getopt error check still relies on $? under set -e'
+    exit 1
+fi
+

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -941,7 +941,7 @@ usage() {
 Usage: $0 COMMAND [ARG...]
 
 Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+  init   [-a | --accept-license] [-k | --kernel KERNEL_VERSION] [-m | --max-threads MAX_THREADS] [-t | --tag PACKAGE_TAG]
 EOF
     exit 1
 }
@@ -950,13 +950,14 @@ if [ $# -eq 0 ]; then
     usage
 fi
 command=$1; shift
+options_rc=0
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;
-esac
-if [ $? -ne 0 ]; then
+esac || options_rc=$?
+if [ ${options_rc} -ne 0 ]; then
     usage
 fi
 eval set -- "${options}"


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: init getopt omits -k/--kernel and -t/--tag options.

## Changes
- `ubuntu26.04/nvidia-driver`: init getopt omits -k/--kernel and -t/--tag options.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,8 +1,8 @@
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
-    reload_nvidia_peermem) options="" ;;
-    probe_nvidia_peermem) options="" ;;
-    *) usage ;;
-esac
-if [ $? -ne 0 ]; then
-    usage
-fi
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
+    reload_nvidia_peermem) options="" ;;
+    probe_nvidia_peermem) options="" ;;
+    *) usage ;;
+esac || options_rc=$?
+if [ ${options_rc} -ne 0 ]; then
+    usage
+fi
```

## Tests
- `tests/test_init_options.bash`

```diff
diff --git a/tests/test_init_options.bash b/tests/test_init_options.bash
new file mode 100755
--- /dev/null
+++ b/tests/test_init_options.bash
@@ -0,0 +1,28 @@
+#!/bin/bash
+# Regression test: init getopt must accept the options the parser consumes.
+set -euo pipefail
+
+driver="$(cd "$(dirname "$0")" && pwd)/../ubuntu26.04/nvidia-driver"
+[ -f "$driver" ] || { echo "driver script not found"; exit 1; }
+
+grep -F -q -- '-o am:k:t:' "$driver" || {
+    echo 'FAIL: init getopt short options do not include -k/-t'
+    exit 1
+}
+grep -F -q -- '-l accept-license,max-threads:,kernel:,tag:' "$driver" || {
+    echo 'FAIL: init getopt long options do not include --kernel/--tag'
+    exit 1
+}
+grep -F -q -- '[-k | --kernel KERNEL_VERSION]' "$driver" || {
+    echo 'FAIL: usage does not document --kernel'
+    exit 1
+}
+grep -F -q -- '[-t | --tag PACKAGE_TAG]' "$driver" || {
+    echo 'FAIL: usage does not document --tag'
+    exit 1
+}
+if grep -F -A3 'probe_nvidia_peermem) options="" ;;' "$driver" | grep -F -q 'if [ $? -ne 0 ]; then'; then
+    echo 'FAIL: post-getopt error check still relies on $? under set -e'
+    exit 1
+fi
+
+echo 'PASS: init getopt accepts and documents -k/--kernel and -t/--tag'
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).