### PR TITLE
fix: add missing -k/--kernel and -t/--tag getopt options

### DIFF
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -941,7 +941,7 @@ usage() {
 Usage: $0 COMMAND [ARG...]
 
 Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+  init   [-a | --accept-license] [-k | --kernel KERNEL_VERSION] [-m | --max-threads MAX_THREADS] [-t | --tag PACKAGE_TAG]
 EOF
     exit 1
 }
@@ -951,7 +951,7 @@ if [ $# -eq 0 ]; then
 fi
 command=$1; shift
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: add missing -k/--kernel and -t/--tag getopt options.

## Changes
- `ubuntu26.04/nvidia-driver`: add missing -k/--kernel and -t/--tag getopt options.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -890,8 +890,8 @@
 usage() {
     cat >&2 <<EOF
 Usage: $0 COMMAND [ARG...]
 
 Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+  init   [-a | --accept-license] [-k | --kernel KERNEL_VERSION] [-m | --max-threads MAX_THREADS] [-t | --tag PACKAGE_TAG]
 EOF
     exit 1
 }
@@ -903,5 +903,5 @@
 command=$1; shift
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).