### PR TITLE
fix: set -e aborts before vgpu and nvidia-installer error checks

### DIFF
--- a/tests/test_set_e_error_handling.bash
+++ b/tests/test_set_e_error_handling.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Regression test: command-substitution failures must be caught under set -e.
+set -euo pipefail
+
+driver="$(cd "$(dirname "$0")" && pwd)/../ubuntu26.04/nvidia-driver"
+[ -f "$driver" ] || { echo "driver script not found"; exit 1; }
+
+# The script must still run with set -e for this bug class to matter.
+grep -q '^set -eu$' "$driver"
+
+# _find_vgpu_driver_version: count
+if grep -F -A1 'count=$(vgpu-util count)' "$driver" | grep -F -q 'if [ $? -ne 0 ]'; then
+    echo 'FAIL: count assignment relies on $? under set -e'
+    exit 1
+fi
+grep -F -q 'count=$(vgpu-util count) || rc=$?' "$driver" || {
+    echo 'FAIL: count exit status is not captured'
+    exit 1
+}
+
+# _find_vgpu_driver_version: version
+if grep -F -A1 'version=$(vgpu-util match' "$driver" | grep -F -q 'if [ $? -ne 0 ]'; then
+    echo 'FAIL: version assignment relies on $? under set -e'
+    exit 1
+fi
+grep -F -q 'version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml) || rc=$?' "$driver" || {
+    echo 'FAIL: version exit status is not captured'
+    exit 1
+}
+
+# _resolve_kernel_type
+if grep -F -A1 'kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)' "$driver" | grep -F -q 'if [ $? -ne 0 ]'; then
+    echo 'FAIL: kernel_module_type assignment relies on $? under set -e'
+    exit 1
+fi
+grep -F -q 'kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type) || rc=$?' "$driver" || {
+    echo 'FAIL: kernel_module_type exit status is not captured'
+    exit 1
+}
+
+echo 'PASS: command-substitution errors are handled safely under set -e'

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -604,15 +604,17 @@ _shutdown() {
 _find_vgpu_driver_version() {
     local count=""
     local version=""
+    local rc=0
 
     if [ "${DISABLE_VGPU_VERSION_CHECK}" = "true" ]; then
         echo "vgpu version compatibility check is disabled"
         return 0
     fi
     # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
-         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
+    rc=0
+    count=$(vgpu-util count) || rc=$?
+    if [ ${rc} -ne 0 ]; then
+         echo "cannot find vgpu devices on host, please check /var/log/vgpu-util.log for more details..."
          return 0
     fi
     NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
@@ -623,8 +625,9 @@ _find_vgpu_driver_version() {
     echo "found $NUM_VGPU_DEVICES vgpu devices on host"
 
     # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
+    rc=0
+    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml) || rc=$?
+    if [ ${rc} -ne 0 ]; then
         echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
         return 1
     fi
@@ -761,13 +764,15 @@ _install_userspace_components() {
 }
 
 _resolve_kernel_type() {
+  local rc=0
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
     KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
     KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
+    rc=0
+    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type) || rc=$?
+    if [ ${rc} -ne 0 ]; then
       echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
       _resolve_kernel_type_from_driver_branch
       return 0


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: set -e aborts before vgpu and nvidia-installer error checks.

## Changes
- `ubuntu26.04/nvidia-driver`: set -e aborts before vgpu and nvidia-installer error checks.

## Details
```diff
diff --git a/ubuntu26.04/nvidia-driver b/ubuntu26.04/nvidia-driver
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -567,7 +567,8 @@ _find_vgpu_driver_version() {
     local count=""
     local version=""
-
+    local rc=0
+
     if [ "${DISABLE_VGPU_VERSION_CHECK}" = "true" ]; then
         echo "vgpu version compatibility check is disabled"
@@ -574,6 +575,7 @@ _find_vgpu_driver_version() {
     fi
     # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
-         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
+    rc=0
+    count=$(vgpu-util count) || rc=$?
+    if [ ${rc} -ne 0 ]; then
+         echo "cannot find vgpu devices on host, please check /var/log/vgpu-util.log for more details..."
          return 0
     fi
@@ -586,8 +588,9 @@ _find_vgpu_driver_version() {
     echo "found $NUM_VGPU_DEVICES vgpu devices on host"
 
     # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
+    rc=0
+    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml) || rc=$?
+    if [ ${rc} -ne 0 ]; then
         echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
         return 1
     fi
@@ -712,6 +715,7 @@ _resolve_kernel_type() {
 _resolve_kernel_type() {
+  local rc=0
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
     KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
@@ -717,8 +721,9 @@ _resolve_kernel_type() {
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
+    rc=0
+    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type) || rc=$?
+    if [ ${rc} -ne 0 ]; then
       echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
       _resolve_kernel_type_from_driver_branch
       return 0
```

## Tests
- `tests/test_set_e_error_handling.bash`

```diff
diff --git a/tests/test_set_e_error_handling.bash b/tests/test_set_e_error_handling.bash
new file mode 100755
--- /dev/null
+++ b/tests/test_set_e_error_handling.bash
@@ -0,0 +1,41 @@
+#!/bin/bash
+# Regression test: command-substitution failures must be caught under set -e.
+set -euo pipefail
+
+driver="$(cd "$(dirname "$0")" && pwd)/../ubuntu26.04/nvidia-driver"
+[ -f "$driver" ] || { echo "driver script not found"; exit 1; }
+
+# The script must still run with set -e for this bug class to matter.
+grep -q '^set -eu$' "$driver"
+
+# _find_vgpu_driver_version: count
+if grep -F -A1 'count=$(vgpu-util count)' "$driver" | grep -F -q 'if [ $? -ne 0 ]'; then
+    echo 'FAIL: count assignment relies on $? under set -e'
+    exit 1
+fi
+grep -F -q 'count=$(vgpu-util count) || rc=$?' "$driver" || {
+    echo 'FAIL: count exit status is not captured'
+    exit 1
+}
+
+# _find_vgpu_driver_version: version
+if grep -F -A1 'version=$(vgpu-util match' "$driver" | grep -F -q 'if [ $? -ne 0 ]'; then
+    echo 'FAIL: version assignment relies on $? under set -e'
+    exit 1
+fi
+grep -F -q 'version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml) || rc=$?' "$driver" || {
+    echo 'FAIL: version exit status is not captured'
+    exit 1
+}
+
+# _resolve_kernel_type
+if grep -F -A1 'kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)' "$driver" | grep -F -q 'if [ $? -ne 0 ]'; then
+    echo 'FAIL: kernel_module_type assignment relies on $? under set -e'
+    exit 1
+fi
+grep -F -q 'kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type) || rc=$?' "$driver" || {
+    echo 'FAIL: kernel_module_type exit status is not captured'
+    exit 1
+}
+
+echo 'PASS: command-substitution errors are handled safely under set -e'
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).