### PR TITLE
fix: getopt rejects -k/--kernel and -t/--tag options

### DIFF
--- a/tests/test_option_parsing.sh
+++ b/tests/test_option_parsing.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+driver_script="ubuntu26.04/nvidia-driver"
+getopt_line=$(grep -E 'init\).*getopt' "$driver_script")
+if ! grep -q 'kernel:' <<<"$getopt_line"; then
+    echo "FAIL: --kernel not supported by getopt" >&2
+    exit 1
+fi
+if ! grep -q 'tag:' <<<"$getopt_line"; then
+    echo "FAIL: --tag not supported by getopt" >&2
+    exit 1
+fi

--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -951,7 +951,7 @@ if [ $# -eq 0 ]; then
 fi
 command=$1; shift
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu26.04/nvidia-driver`: getopt rejects -k/--kernel and -t/--tag options.

## Changes
- `ubuntu26.04/nvidia-driver`: getopt rejects -k/--kernel and -t/--tag options.

## Details
```diff
--- a/ubuntu26.04/nvidia-driver
+++ b/ubuntu26.04/nvidia-driver
@@ -1,1 +1,1 @@
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@") ;;
```

## Tests
- `tests/test_option_parsing.sh`

```diff
--- /dev/null
+++ b/tests/test_option_parsing.sh
@@ -0,0 +1,12 @@
+#!/bin/bash
+set -e
+driver_script="ubuntu26.04/nvidia-driver"
+getopt_line=$(grep -E 'init\).*getopt' "$driver_script")
+if ! grep -q 'kernel:' <<<"$getopt_line"; then
+    echo "FAIL: --kernel not supported by getopt" >&2
+    exit 1
+fi
+if ! grep -q 'tag:' <<<"$getopt_line"; then
+    echo "FAIL: --tag not supported by getopt" >&2
+    exit 1
+fi
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).