### PR TITLE
fix: vgpu-util failures abort under set -e instead of being handled

### DIFF
--- a/test_vgpu_util_handling.sh
+++ b/test_vgpu_util_handling.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Regression test for _find_vgpu_driver_version error handling.
+# The function must not abort under 'set -e' when vgpu-util returns an error.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")/.." && pwd)
+driver_script="$script_dir/ubuntu24.04/nvidia-driver"
+
+func=$(awk '/^_find_vgpu_driver_version\(\) \{/,/^}$/' "$driver_script")
+if [[ -z "$func" ]]; then
+    echo "ERROR: could not extract _find_vgpu_driver_version" >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+tmp_script="$tmp/test.sh"
+
+{
+    printf '%s\n' "$func"
+    cat <<'EOF'
+
+DISABLE_VGPU_VERSION_CHECK=false
+NUM_VGPU_DEVICES=0
+DRIVER_VERSION=test
+DRIVER_TYPE=vgpu
+
+vgpu-util() {
+    return 1
+}
+
+_find_vgpu_driver_version
+EOF
+} > "$tmp_script"
+
+if bash -e "$tmp_script" >/dev/null 2>&1; then
+    echo "PASS: vgpu-util failure is handled gracefully"
+else
+    echo "FAIL: vgpu-util failure caused an unexpected abort"
+    exit 1
+fi

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -550,8 +550,7 @@ _find_vgpu_driver_version() {
         return 0
     fi
     # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
+    if ! count=$(vgpu-util count); then
          echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
          return 0
     fi
@@ -563,8 +562,7 @@ _find_vgpu_driver_version() {
     echo "found $NUM_VGPU_DEVICES vgpu devices on host"
 
     # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
+    if ! version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml); then
         echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
         return 1
     fi


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: vgpu-util failures abort under set -e instead of being handled.

## Changes
- `ubuntu24.04/nvidia-driver`: vgpu-util failures abort under set -e instead of being handled.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,19 +1,17 @@
-    # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
-         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
-         return 0
-    fi
-    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
-    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
-        # no vgpu devices found, treat as passthrough
-        return 0
-    fi
-    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
-
-    # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
-        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
-        return 1
-    fi
+    # check if vgpu devices are present
+    if ! count=$(vgpu-util count); then
+         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
+         return 0
+    fi
+    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
+    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
+        # no vgpu devices found, treat as passthrough
+        return 0
+    fi
+    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
+
+    # find compatible guest driver using drive catalog
+    if ! version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml); then
+        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
+        return 1
+    fi
```

## Tests
- `tests/test_vgpu_util_handling.sh`

```diff
--- /dev/null
+++ tests/test_vgpu_util_handling.sh
@@ -0,0 +1,41 @@
+#!/usr/bin/env bash
+# Regression test for _find_vgpu_driver_version error handling.
+# The function must not abort under 'set -e' when vgpu-util returns an error.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")/.." && pwd)
+driver_script="$script_dir/ubuntu24.04/nvidia-driver"
+
+func=$(awk '/^_find_vgpu_driver_version\(\) \{/,/^}$/' "$driver_script")
+if [[ -z "$func" ]]; then
+    echo "ERROR: could not extract _find_vgpu_driver_version" >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+tmp_script="$tmp/test.sh"
+
+{
+    printf '%s\n' "$func"
+    cat <<'EOF'
+
+DISABLE_VGPU_VERSION_CHECK=false
+NUM_VGPU_DEVICES=0
+DRIVER_VERSION=test
+DRIVER_TYPE=vgpu
+
+vgpu-util() {
+    return 1
+}
+
+_find_vgpu_driver_version
+EOF
+} > "$tmp_script"
+
+if bash -e "$tmp_script" >/dev/null 2>&1; then
+    echo "PASS: vgpu-util failure is handled gracefully"
+else
+    echo "FAIL: vgpu-util failure caused an unexpected abort"
+    exit 1
+fi
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).