### PR TITLE
fix: OFA kernel symlink fails on rerun if /usr/src/ofa_kernel exists

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -144,7 +144,10 @@ _remove_prerequisites() {
 # or kernel-version folder.
 _link_ofa_kernel() (
     if _gpu_direct_rdma_enabled; then
-        ln -s /run/mellanox/drivers/usr/src/ofa_kernel /usr/src/
+        # Only create the top-level symlink if it doesn't already exist.
+        if [[ ! -e /usr/src/ofa_kernel ]]; then
+            ln -s /run/mellanox/drivers/usr/src/ofa_kernel /usr/src/
+        fi
         # if arch directory exists(MOFED >=5.5) then create a symlink as expected by GPU driver installer
         # ls -ltr /usr/src/ofa_kernel/
         # lrwxrwxrwx 1 root root   36 Dec  8 20:10 default -> /etc/alternatives/ofa_kernel_headers


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: OFA kernel symlink fails on rerun if /usr/src/ofa_kernel exists.

## Changes
- `ubuntu24.04/nvidia-driver`: OFA kernel symlink fails on rerun if /usr/src/ofa_kernel exists.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,2 +1,5 @@
-        ln -s /run/mellanox/drivers/usr/src/ofa_kernel /usr/src/
-        # if arch directory exists(MOFED >=5.5) then create a symlink as expected by GPU driver installer
+        # Only create the top-level symlink if it doesn't already exist.
+        if [[ ! -e /usr/src/ofa_kernel ]]; then
+            ln -s /run/mellanox/drivers/usr/src/ofa_kernel /usr/src/
+        fi
+        # if arch directory exists(MOFED >=5.5) then create a symlink as expected by GPU driver installer
```

## Tests
- `tests/test_link_ofa_kernel_idempotent.sh`

```diff
--- /dev/null
+++ tests/test_link_ofa_kernel_idempotent.sh
@@ -0,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression test for _link_ofa_kernel symlink idempotency.
+# A pre-existing /usr/src/ofa_kernel must not cause the init to abort.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")/.." && pwd)
+driver_script="$script_dir/ubuntu24.04/nvidia-driver"
+
+func=$(awk '/^_link_ofa_kernel\(\) \(/,/^)$/' "$driver_script")
+if [[ -z "$func" ]]; then
+    echo "ERROR: could not extract _link_ofa_kernel" >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+kernel=$(uname -r)
+arch=x86_64
+
+mkdir -p "$tmp/usr/src"
+mkdir -p "$tmp/run/mellanox/drivers/usr/src/ofa_kernel/$arch/$kernel"
+# Simulate a pre-existing /usr/src/ofa_kernel (e.g. from a prior run).
+mkdir -p "$tmp/usr/src/ofa_kernel"
+
+# Rewrite absolute paths in the extracted function to use the temp directory.
+rewritten=$(printf '%s\n' "$func" | sed \
+    -e "s|/usr/src|$tmp/usr/src|g" \
+    -e "s|/run/mellanox/drivers|$tmp/run/mellanox/drivers|g")
+
+tmp_script="$tmp/test.sh"
+
+{
+    printf '%s\n' "$rewritten"
+    cat <<EOF
+
+set -e
+DRIVER_ARCH=$arch
+_gpu_direct_rdma_enabled() { return 0; }
+
+_link_ofa_kernel
+EOF
+} > "$tmp_script"
+
+if bash -e "$tmp_script" >/dev/null 2>&1; then
+    echo "PASS: _link_ofa_kernel tolerates existing /usr/src/ofa_kernel"
+else
+    echo "FAIL: _link_ofa_kernel failed when /usr/src/ofa_kernel already exists"
+    exit 1
+fi
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).