### PR TITLE
fix: OFA kernel symlink uses running kernel instead of KERNEL_VERSION

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -150,9 +150,9 @@ _link_ofa_kernel() (
         # lrwxrwxrwx 1 root root   36 Dec  8 20:10 default -> /etc/alternatives/ofa_kernel_headers
         # drwxr-xr-x 4 root root 4096 Dec  8 20:14 x86_64
         # lrwxrwxrwx 1 root root   44 Dec  9 19:05 5.4.0-90-generic -> /usr/src/ofa_kernel/x86_64/5.4.0-90-generic/
-        if [[ -d /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/$(uname -r) ]]; then
-            if [[ ! -e /usr/src/ofa_kernel/$(uname -r) ]]; then
-                ln -s /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/$(uname -r) /usr/src/ofa_kernel/
+        if [[ -d /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/${KERNEL_VERSION} ]]; then
+            if [[ ! -e /usr/src/ofa_kernel/${KERNEL_VERSION} ]]; then
+                ln -s /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/${KERNEL_VERSION} /usr/src/ofa_kernel/
             fi
         fi
     fi


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: OFA kernel symlink uses running kernel instead of KERNEL_VERSION.

## Changes
- `ubuntu24.04/nvidia-driver`: OFA kernel symlink uses running kernel instead of KERNEL_VERSION.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,5 +1,5 @@
-        if [[ -d /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/$(uname -r) ]]; then
-            if [[ ! -e /usr/src/ofa_kernel/$(uname -r) ]]; then
-                ln -s /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/$(uname -r) /usr/src/ofa_kernel/
-            fi
-        fi
+        if [[ -d /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/${KERNEL_VERSION} ]]; then
+            if [[ ! -e /usr/src/ofa_kernel/${KERNEL_VERSION} ]]; then
+                ln -s /run/mellanox/drivers/usr/src/ofa_kernel/$DRIVER_ARCH/${KERNEL_VERSION} /usr/src/ofa_kernel/
+            fi
+        fi
```

## Tests
- `tests/test_nvidia-driver-ofa-kernel.sh`

```diff
--- /dev/null
+++ b/tests/test_nvidia-driver-ofa-kernel.sh
@@ -0,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${ROOT_DIR}/ubuntu24.04/nvidia-driver"
+
+if awk '/^_link_ofa_kernel\(\)/,/^}/' "$SCRIPT" | grep -q '$(uname -r)'; then
+    echo "FAIL: _link_ofa_kernel still uses hard-coded uname -r instead of KERNEL_VERSION" >&2
+    exit 1
+fi
+
+echo "OK"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).