### PR TITLE
fix: stale daemon PID file makes driver unload abort

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -338,7 +338,7 @@ _unload_driver() {
         echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
@@ -353,7 +353,7 @@ _unload_driver() {
         echo "Stopping NVIDIA grid daemon..."
         local pid=$(< /var/run/nvidia-gridd/nvidia-gridd.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
@@ -368,7 +368,7 @@ _unload_driver() {
         echo "Stopping NVIDIA topology daemon..."
         local pid=$(< /var/run/nvidia-topologyd/nvidia-topologyd.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
@@ -383,7 +383,7 @@ _unload_driver() {
         echo "Stopping NVIDIA fabric manager daemon..."
         local pid=$(< /var/run/nvidia-fabricmanager/nv-fabricmanager.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
@@ -398,7 +398,7 @@ _unload_driver() {
         echo "Stopping NVLink Subnet Manager daemon..."
         local pid=$(< /var/run/nvidia-fabricmanager/nvlsm.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: stale daemon PID file makes driver unload abort.

## Changes
- `ubuntu24.04/nvidia-driver`: stale daemon PID file makes driver unload abort.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -335,14 +335,14 @@
     if [ -f /var/run/nvidia-persistenced/nvidia-persistenced.pid ]; then
         echo "Stopping NVIDIA persistence daemon..."
         local pid=$(< /var/run/nvidia-persistenced/nvidia-persistenced.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
         done
@@ -350,14 +350,14 @@
     if [ -f /var/run/nvidia-gridd/nvidia-gridd.pid ]; then
         echo "Stopping NVIDIA grid daemon..."
         local pid=$(< /var/run/nvidia-gridd/nvidia-gridd.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
         done
@@ -365,14 +365,14 @@
     if [ -f /var/run/nvidia-topologyd/nvidia-topologyd.pid ]; then
         echo "Stopping NVIDIA topology daemon..."
         local pid=$(< /var/run/nvidia-topologyd/nvidia-topologyd.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
         done
@@ -380,14 +380,14 @@
     if [ -f /var/run/nvidia-fabricmanager/nv-fabricmanager.pid ]; then
         echo "Stopping NVIDIA fabric manager daemon..."
         local pid=$(< /var/run/nvidia-fabricmanager/nv-fabricmanager.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
         done
@@ -395,14 +395,14 @@
     if [ -f /var/run/nvidia-fabricmanager/nvlsm.pid ]; then
         echo "Stopping NVLink Subnet Manager daemon..."
         local pid=$(< /var/run/nvidia-fabricmanager/nvlsm.pid)
 
-        kill -SIGTERM "${pid}"
+        kill -SIGTERM "${pid}" 2>/dev/null || true
         for i in $(seq 1 50); do
             kill -0 "${pid}" 2> /dev/null || break
             sleep 0.1
         done
```

## Tests
- `tests/test_nvidia-driver-unload-kill.sh`

```diff
--- /dev/null
+++ b/tests/test_nvidia-driver-unload-kill.sh
@@ -0,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${ROOT_DIR}/ubuntu24.04/nvidia-driver"
+
+if awk '/^_unload_driver\(\)/,/^}/' "$SCRIPT" | grep -E '^[[:space:]]+kill -SIGTERM' | grep -v '|| true' | grep -q .; then
+    echo "FAIL: unguarded kill -SIGTERM in _unload_driver may abort on stale PID" >&2
+    exit 1
+fi
+
+echo "OK"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).