### PR TITLE
fix: nvidia-installer fallback ignored under set -e

### DIFF
--- a/tests/test_resolve_kernel_type.sh
+++ b/tests/test_resolve_kernel_type.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -u
+set -e
+
+REPO_ROOT=$(cd $(dirname $0)/.. && pwd)
+DRIVER_SCRIPT=$REPO_ROOT/ubuntu24.04/nvidia-driver
+
+if [[ ! -f $DRIVER_SCRIPT ]]; then
+    echo 'FAIL: driver script not found: '$DRIVER_SCRIPT >&2
+    exit 1
+fi
+
+mkdir -p fakebin
+cat > fakebin/nvidia-installer <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x fakebin/nvidia-installer
+
+tmp=$(mktemp)
+cleanup() { rm -f $tmp; }
+trap cleanup EXIT
+
+{
+    echo 'set -eu'
+    sed -n '/^_resolve_kernel_type_from_driver_branch()/,/^}/p' $DRIVER_SCRIPT
+    sed -n '/^_resolve_kernel_type()/,/^}/p' $DRIVER_SCRIPT
+    echo 'KERNEL_MODULE_TYPE=auto'
+    echo 'DRIVER_BRANCH=560'
+    echo '_resolve_kernel_type || exit 1'
+    echo 'echo KERNEL_TYPE=$KERNEL_TYPE'
+} > $tmp
+
+PATH=$PWD/fakebin:$PATH bash $tmp >out.txt 2>&1
+rc=$?
+
+if [[ $rc -ne 0 ]] || ! grep -q KERNEL_TYPE=kernel-open out.txt; then
+    echo 'FAIL: _resolve_kernel_type did not fall back to branch-based kernel type (rc='$rc')' >&2
+    cat out.txt >&2
+    exit 1

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -706,8 +706,7 @@ _resolve_kernel_type() {
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
     KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
+    if ! kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type); then
       echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
       _resolve_kernel_type_from_driver_branch
       return 0


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: nvidia-installer fallback ignored under set -e.

## Changes
- `ubuntu24.04/nvidia-driver`: nvidia-installer fallback ignored under set -e.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,18 +1,17 @@
-_resolve_kernel_type() {
-  if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
-    KERNEL_TYPE=kernel
-  elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
-    KERNEL_TYPE=kernel-open
-  elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
-      echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
-      _resolve_kernel_type_from_driver_branch
-      return 0
-    fi
-    [[ "${kernel_module_type}" == "open" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
-  else
-    echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}"
-    return 1
-  fi
-}
+_resolve_kernel_type() {
+  if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
+    KERNEL_TYPE=kernel
+  elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
+    KERNEL_TYPE=kernel-open
+  elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
+    if ! kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type); then
+      echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
+      _resolve_kernel_type_from_driver_branch
+      return 0
+    fi
+    [[ "${kernel_module_type}" == "open" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
+  else
+    echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}"
+    return 1
+  fi
+}
```

## Tests
- `tests/test_resolve_kernel_type.sh`

```diff
diff --git a/tests/test_resolve_kernel_type.sh b/tests/test_resolve_kernel_type.sh
new file mode 100755
--- /dev/null
+++ b/tests/test_resolve_kernel_type.sh
@@ -0,0 +1,40 @@
+#!/bin/bash
+set -u
+set -e
+
+REPO_ROOT=$(cd $(dirname $0)/.. && pwd)
+DRIVER_SCRIPT=$REPO_ROOT/ubuntu24.04/nvidia-driver
+
+if [[ ! -f $DRIVER_SCRIPT ]]; then
+    echo 'FAIL: driver script not found: '$DRIVER_SCRIPT >&2
+    exit 1
+fi
+
+mkdir -p fakebin
+cat > fakebin/nvidia-installer <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x fakebin/nvidia-installer
+
+tmp=$(mktemp)
+cleanup() { rm -f $tmp; }
+trap cleanup EXIT
+
+{
+    echo 'set -eu'
+    sed -n '/^_resolve_kernel_type_from_driver_branch()/,/^}/p' $DRIVER_SCRIPT
+    sed -n '/^_resolve_kernel_type()/,/^}/p' $DRIVER_SCRIPT
+    echo 'KERNEL_MODULE_TYPE=auto'
+    echo 'DRIVER_BRANCH=560'
+    echo '_resolve_kernel_type || exit 1'
+    echo 'echo KERNEL_TYPE=$KERNEL_TYPE'
+} > $tmp
+
+PATH=$PWD/fakebin:$PATH bash $tmp >out.txt 2>&1
+rc=$?
+
+if [[ $rc -ne 0 ]] || ! grep -q KERNEL_TYPE=kernel-open out.txt; then
+    echo 'FAIL: _resolve_kernel_type did not fall back to branch-based kernel type (rc='$rc')' >&2
+    cat out.txt >&2
+    exit 1
+fi
+
+echo 'PASS'
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).