### PR TITLE
fix: vgpu-util failure aborts instead of passthrough

### DIFF
--- a/tests/test_vgpu_version_check.sh
+++ b/tests/test_vgpu_version_check.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -u
+set -e
+
+REPO_ROOT=$(cd $(dirname $0)/.. && pwd)
+DRIVER_SCRIPT=$REPO_ROOT/ubuntu24.04/nvidia-driver
+
+if [[ ! -f $DRIVER_SCRIPT ]]; then
+    echo 'FAIL: driver script not found: '$DRIVER_SCRIPT >&2
+    exit 1
+fi
+
+mkdir -p fakebin
+cat > fakebin/vgpu-util <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x fakebin/vgpu-util
+
+tmp=$(mktemp)
+cleanup() { rm -f $tmp; }
+trap cleanup EXIT
+
+{
+    echo 'set -eu'
+    sed -n '/^_find_vgpu_driver_version()/,/^}/p' $DRIVER_SCRIPT
+    echo 'DISABLE_VGPU_VERSION_CHECK=false'
+    echo '_find_vgpu_driver_version'
+} > $tmp
+
+PATH=$PWD/fakebin:$PATH bash $tmp >out.txt 2>&1
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+    echo 'FAIL: _find_vgpu_driver_version aborted on vgpu-util failure (rc='$rc')' >&2
+    cat out.txt >&2
+    exit 1
+fi

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -550,8 +550,7 @@ _find_vgpu_driver_version() {
         return 0
     fi
     # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
+    if ! count=$(vgpu-util count); then
          echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
          return 0
     fi
@@ -563,8 +562,7 @@ _find_vgpu_driver_version() {
     echo "found $NUM_VGPU_DEVICES vgpu devices on host"
 
     # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
+    if ! version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml); then
         echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
         return 1
     fi


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: vgpu-util failure aborts instead of passthrough.

## Changes
- `ubuntu24.04/nvidia-driver`: vgpu-util failure aborts instead of passthrough.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,31 +1,29 @@
-_find_vgpu_driver_version() {
-    local count=""
-    local version=""
-
-    if [ "${DISABLE_VGPU_VERSION_CHECK}" = "true" ]; then
-        echo "vgpu version compatibility check is disabled"
-        return 0
-    fi
-    # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
-         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
-         return 0
-    fi
-    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
-    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
-        # no vgpu devices found, treat as passthrough
-        return 0
-    fi
-    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
-
-    # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
-        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
-        return 1
-    fi
-    DRIVER_VERSION=$(echo "$version" | awk -F= '{print $2}')
-    echo "vgpu driver version selected: ${DRIVER_VERSION}"
-    return 0
-}
+_find_vgpu_driver_version() {
+    local count=""
+    local version=""
+
+    if [ "${DISABLE_VGPU_VERSION_CHECK}" = "true" ]; then
+        echo "vgpu version compatibility check is disabled"
+        return 0
+    fi
+    # check if vgpu devices are present
+    if ! count=$(vgpu-util count); then
+         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
+         return 0
+    fi
+    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
+    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
+        # no vgpu devices found, treat as passthrough
+        return 0
+    fi
+    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
+
+    # find compatible guest driver using drive catalog
+    if ! version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml); then
+        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
+        return 1
+    fi
+    DRIVER_VERSION=$(echo "$version" | awk -F= '{print $2}')
+    echo "vgpu driver version selected: ${DRIVER_VERSION}"
+    return 0
+}
```

## Tests
- `tests/test_vgpu_version_check.sh`

```diff
diff --git a/tests/test_vgpu_version_check.sh b/tests/test_vgpu_version_check.sh
new file mode 100755
--- /dev/null
+++ b/tests/test_vgpu_version_check.sh
@@ -0,0 +1,38 @@
+#!/bin/bash
+set -u
+set -e
+
+REPO_ROOT=$(cd $(dirname $0)/.. && pwd)
+DRIVER_SCRIPT=$REPO_ROOT/ubuntu24.04/nvidia-driver
+
+if [[ ! -f $DRIVER_SCRIPT ]]; then
+    echo 'FAIL: driver script not found: '$DRIVER_SCRIPT >&2
+    exit 1
+fi
+
+mkdir -p fakebin
+cat > fakebin/vgpu-util <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x fakebin/vgpu-util
+
+tmp=$(mktemp)
+cleanup() { rm -f $tmp; }
+trap cleanup EXIT
+
+{
+    echo 'set -eu'
+    sed -n '/^_find_vgpu_driver_version()/,/^}/p' $DRIVER_SCRIPT
+    echo 'DISABLE_VGPU_VERSION_CHECK=false'
+    echo '_find_vgpu_driver_version'
+} > $tmp
+
+PATH=$PWD/fakebin:$PATH bash $tmp >out.txt 2>&1
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+    echo 'FAIL: _find_vgpu_driver_version aborted on vgpu-util failure (rc='$rc')' >&2
+    cat out.txt >&2
+    exit 1
+fi
+
+echo 'PASS'
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).