### PR TITLE
fix: init getopt ignores --kernel/--tag and dead error path

### DIFF
--- a/tests/test_getopt_options.sh
+++ b/tests/test_getopt_options.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -u
+set -e
+
+REPO_ROOT=$(cd $(dirname $0)/.. && pwd)
+DRIVER_SCRIPT=$REPO_ROOT/ubuntu24.04/nvidia-driver
+
+if [[ ! -f $DRIVER_SCRIPT ]]; then
+    echo 'FAIL: driver script not found: '$DRIVER_SCRIPT >&2
+    exit 1
+fi
+
+tmp=$(mktemp)
+cleanup() { rm -f $tmp; }
+trap cleanup EXIT
+
+{
+    echo 'usage() { echo USAGE; exit 1; }'
+    echo 'init() { echo INIT_OK KERNEL_VERSION=$KERNEL_VERSION PACKAGE_TAG=$PACKAGE_TAG ACCEPT_LICENSE=$ACCEPT_LICENSE MAX_THREADS=$MAX_THREADS; }'
+    sed -n '/^if \[ \$# -eq 0 \]/,/^\$command$/p' $DRIVER_SCRIPT
+} > $tmp
+
+if ! out=$(bash $tmp init -k 6.8.0-generic -t builtin -a -m 4); then
+    echo 'FAIL: option parsing script exited non-zero (getopt likely rejected -k/-t)' >&2
+    exit 1
+fi
+
+expected='INIT_OK KERNEL_VERSION=6.8.0-generic PACKAGE_TAG=builtin ACCEPT_LICENSE=yes MAX_THREADS=4'
+if [[ $out != $expected ]]; then
+    echo 'FAIL: expected '$expected', got '$out'' >&2
+    exit 1
+fi

--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -845,7 +845,7 @@ usage() {
 Usage: $0 COMMAND [ARG...]
 
 Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
+  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS] [-k | --kernel KERNEL_VERSION] [-t | --tag PACKAGE_TAG]
 EOF
     exit 1
 }
@@ -855,14 +855,11 @@ if [ $# -eq 0 ]; then
 fi
 command=$1; shift
 case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
+    init) if ! options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@"); then usage; fi ;;
     reload_nvidia_peermem) options="" ;;
     probe_nvidia_peermem) options="" ;;
     *) usage ;;
 esac
-if [ $? -ne 0 ]; then
-    usage
-fi
 eval set -- "${options}"
 
 ACCEPT_LICENSE=""


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: init getopt ignores --kernel/--tag and dead error path.

## Changes
- `ubuntu24.04/nvidia-driver`: init getopt ignores --kernel/--tag and dead error path.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,44 +1,41 @@
-usage() {
-    cat >&2 <<EOF
-Usage: $0 COMMAND [ARG...]
-
-Commands:
-  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS]
-EOF
-    exit 1
-}
-
-if [ $# -eq 0 ]; then
-    usage
-fi
-command=$1; shift
-case "${command}" in
-    init) options=$(getopt -l accept-license,max-threads: -o am: -- "$@") ;;
-    reload_nvidia_peermem) options="" ;;
-    probe_nvidia_peermem) options="" ;;
-    *) usage ;;
-esac
-if [ $? -ne 0 ]; then
-    usage
-fi
-eval set -- "${options}"
-
-ACCEPT_LICENSE=""
-MAX_THREADS=""
-KERNEL_VERSION=$(uname -r)
-PACKAGE_TAG=""
-
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
-    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
-    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
-    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
-    --) shift; break ;;
-    esac
-done
-if [ $# -ne 0 ]; then
-    usage
-fi
-
-$command
+usage() {
+    cat >&2 <<EOF
+Usage: $0 COMMAND [ARG...]
+
+Commands:
+  init   [-a | --accept-license] [-m | --max-threads MAX_THREADS] [-k | --kernel KERNEL_VERSION] [-t | --tag PACKAGE_TAG]
+EOF
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+command=$1; shift
+case "${command}" in
+    init) if ! options=$(getopt -l accept-license,max-threads:,kernel:,tag: -o am:k:t: -- "$@"); then usage; fi ;;
+    reload_nvidia_peermem) options="" ;;
+    probe_nvidia_peermem) options="" ;;
+    *) usage ;;
+esac
+eval set -- "${options}"
+
+ACCEPT_LICENSE=""
+MAX_THREADS=""
+KERNEL_VERSION=$(uname -r)
+PACKAGE_TAG=""
+
+for opt in ${options}; do
+    case "$opt" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
+    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
+    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
+    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+    --) shift; break ;;
+    esac
+done
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+$command
```

## Tests
- `tests/test_getopt_options.sh`

```diff
diff --git a/tests/test_getopt_options.sh b/tests/test_getopt_options.sh
new file mode 100755
--- /dev/null
+++ b/tests/test_getopt_options.sh
@@ -0,0 +1,32 @@
+#!/bin/bash
+set -u
+set -e
+
+REPO_ROOT=$(cd $(dirname $0)/.. && pwd)
+DRIVER_SCRIPT=$REPO_ROOT/ubuntu24.04/nvidia-driver
+
+if [[ ! -f $DRIVER_SCRIPT ]]; then
+    echo 'FAIL: driver script not found: '$DRIVER_SCRIPT >&2
+    exit 1
+fi
+
+tmp=$(mktemp)
+cleanup() { rm -f $tmp; }
+trap cleanup EXIT
+
+{
+    echo 'usage() { echo USAGE; exit 1; }'
+    echo 'init() { echo INIT_OK KERNEL_VERSION=$KERNEL_VERSION PACKAGE_TAG=$PACKAGE_TAG ACCEPT_LICENSE=$ACCEPT_LICENSE MAX_THREADS=$MAX_THREADS; }'
+    sed -n '/^if \[ \$# -eq 0 \]/,/^\$command$/p' $DRIVER_SCRIPT
+} > $tmp
+
+if ! out=$(bash $tmp init -k 6.8.0-generic -t builtin -a -m 4); then
+    echo 'FAIL: option parsing script exited non-zero (getopt likely rejected -k/-t)' >&2
+    exit 1
+fi
+
+expected='INIT_OK KERNEL_VERSION=6.8.0-generic PACKAGE_TAG=builtin ACCEPT_LICENSE=yes MAX_THREADS=4'
+if [[ $out != $expected ]]; then
+    echo 'FAIL: expected '$expected', got '$out'' >&2
+    exit 1
+fi
+
+echo 'PASS'
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).