### PR TITLE
fix: modprobe config lines have unquoted arrays/paths

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -269,19 +269,19 @@ _create_module_params_conf() {
 
     if [ ${#NVIDIA_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia module parameters in ${MODPROBE_CONFIG_DIR}/nvidia.conf"
-        echo "options nvidia ${NVIDIA_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia.conf
+        echo "options nvidia ${NVIDIA_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia.conf"
     fi
     if [ ${#NVIDIA_UVM_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia-uvm module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf"
-        echo "options nvidia-uvm ${NVIDIA_UVM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf
+        echo "options nvidia-uvm ${NVIDIA_UVM_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf"
     fi
     if [ ${#NVIDIA_MODESET_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia-modeset module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf"
-        echo "options nvidia-modeset ${NVIDIA_MODESET_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf
+        echo "options nvidia-modeset ${NVIDIA_MODESET_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf"
     fi
     if [ ${#NVIDIA_PEERMEM_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia-peermem module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf"
-        echo "options nvidia-peermem ${NVIDIA_PEERMEM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf
+        echo "options nvidia-peermem ${NVIDIA_PEERMEM_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf"
     fi
 }
 


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: modprobe config lines have unquoted arrays/paths.

## Changes
- `ubuntu24.04/nvidia-driver`: modprobe config lines have unquoted arrays/paths.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -365,19 +365,19 @@ _create_module_params_conf() {
 
     if [ ${#NVIDIA_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia module parameters in ${MODPROBE_CONFIG_DIR}/nvidia.conf"
-        echo "options nvidia ${NVIDIA_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia.conf
+        echo "options nvidia ${NVIDIA_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia.conf"
     fi
     if [ ${#NVIDIA_UVM_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia-uvm module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf"
-        echo "options nvidia-uvm ${NVIDIA_UVM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf
+        echo "options nvidia-uvm ${NVIDIA_UVM_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf"
     fi
     if [ ${#NVIDIA_MODESET_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia-modeset module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf"
-        echo "options nvidia-modeset ${NVIDIA_MODESET_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf
+        echo "options nvidia-modeset ${NVIDIA_MODESET_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf"
     fi
     if [ ${#NVIDIA_PEERMEM_MODULE_PARAMS[@]} -gt 0 ]; then
         echo "Configuring nvidia-peermem module parameters in ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf"
-        echo "options nvidia-peermem ${NVIDIA_PEERMEM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf
+        echo "options nvidia-peermem ${NVIDIA_PEERMEM_MODULE_PARAMS[*]}" > "${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf"
     fi
 }
```

## Tests
- `tests/test_modprobe_config_quoting.sh`

```diff
--- /dev/null
+++ tests/test_modprobe_config_quoting.sh
@@ -0,0 +1,25 @@
+#!/bin/bash
+set -eu
+
+DRIVER_FILE="ubuntu24.04/nvidia-driver"
+
+check_line() {
+    if grep -F "$1" "$DRIVER_FILE"; then
+        echo "FAIL: $2" >&2
+        exit 1
+    fi
+}
+
+check_line '        echo "options nvidia ${NVIDIA_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia.conf' \
+    "unquoted nvidia modprobe config"
+check_line '        echo "options nvidia-uvm ${NVIDIA_UVM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-uvm.conf' \
+    "unquoted nvidia-uvm modprobe config"
+check_line '        echo "options nvidia-modeset ${NVIDIA_MODESET_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-modeset.conf' \
+    "unquoted nvidia-modeset modprobe config"
+check_line '        echo "options nvidia-peermem ${NVIDIA_PEERMEM_MODULE_PARAMS[@]}" > ${MODPROBE_CONFIG_DIR}/nvidia-peermem.conf' \
+    "unquoted nvidia-peermem modprobe config"
+
+echo "PASS: modprobe config lines quote array values and paths"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).