### PR TITLE
fix: nvidia-installer failure aborts under set -e before $? check

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -706,8 +706,7 @@ _resolve_kernel_type() {
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
     KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
+    if ! kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type); then
       echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
       _resolve_kernel_type_from_driver_branch
       return 0


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: nvidia-installer failure aborts under set -e before $? check.

## Changes
- `ubuntu24.04/nvidia-driver`: nvidia-installer failure aborts under set -e before $? check.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,6 +1,5 @@
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
-      echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
-      _resolve_kernel_type_from_driver_branch
-      return 0
-    fi
+    if ! kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type); then
+      echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
+      _resolve_kernel_type_from_driver_branch
+      return 0
+    fi
```

## Tests
- `tests/test_resolve_kernel_type.sh`

```diff
--- /dev/null
+++ tests/test_resolve_kernel_type.sh
@@ -0,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+DRIVER_FILE="ubuntu24.04/nvidia-driver"
+
+if grep -F '    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)' "$DRIVER_FILE"; then
+    echo "FAIL: nvidia-installer uses unchecked command substitution" >&2
+    exit 1
+fi
+
+echo "PASS: nvidia-installer error is caught with conditional command substitution"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).