### PR TITLE
fix: sed pipeline passes stray stdin '-' argument

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -124,7 +124,7 @@ _install_prerequisites() (
 
     echo "Generating Linux kernel version string..."
 
-    ls -1 boot/vmlinuz-* | sed  's/\/boot\/vmlinuz-//g' - > version
+    ls -1 boot/vmlinuz-* | sed  's/\/boot\/vmlinuz-//g' > version
     if [ -z "$(<version)" ]; then
         echo "Could not locate Linux kernel version string" >&2
         return 1


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: sed pipeline passes stray stdin '-' argument.

## Changes
- `ubuntu24.04/nvidia-driver`: sed pipeline passes stray stdin '-' argument.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,1 +1,1 @@
-    ls -1 boot/vmlinuz-* | sed  's/\/boot\/vmlinuz-//g' - > version
+    ls -1 boot/vmlinuz-* | sed  's/\/boot\/vmlinuz-//g' > version
```

## Tests
- `tests/test_sed_pipeline.sh`

```diff
--- /dev/null
+++ tests/test_sed_pipeline.sh
@@ -0,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+DRIVER_FILE="ubuntu24.04/nvidia-driver"
+
+if grep -F "    ls -1 boot/vmlinuz-* | sed  's/\\/boot\\/vmlinuz-//g' - > version" "$DRIVER_FILE"; then
+    echo "FAIL: sed pipeline still passes stray '-' argument" >&2
+    exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/boot"
+touch "$tmpdir/boot/vmlinuz-5.4.0-test"
+cd "$tmpdir"
+result=$(ls -1 boot/vmlinuz-* | sed 's/\/boot\/vmlinuz-//g')
+if [ "$result" != "5.4.0-test" ]; then
+    echo "FAIL: sed pipeline produced '$result', expected '5.4.0-test'" >&2
+    exit 1
+fi
+
+echo "PASS: sed pipeline is clean and produces correct output"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).