### PR TITLE
fix: unused devices_found variable and unquoted path

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -193,11 +193,10 @@ _ensure_nvlink5_prerequisites() (
 
 # Check if mellanox devices are present
 _mellanox_devices_present() {
-    devices_found=0
     for dev in /sys/bus/pci/devices/*; do
-        read vendor < $dev/vendor
+        read vendor < "$dev/vendor"
         if [ "$vendor" = "0x15b3" ]; then
-            echo "Mellanox device found at $(basename $dev)"
+            echo "Mellanox device found at $(basename "$dev")"
             return 0
         fi
     done


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: unused devices_found variable and unquoted path.

## Changes
- `ubuntu24.04/nvidia-driver`: unused devices_found variable and unquoted path.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,9 +1,8 @@
-_mellanox_devices_present() {
-    devices_found=0
-    for dev in /sys/bus/pci/devices/*; do
-        read vendor < $dev/vendor
-        if [ "$vendor" = "0x15b3" ]; then
-            echo "Mellanox device found at $(basename $dev)"
-            return 0
-        fi
-    done
+_mellanox_devices_present() {
+    for dev in /sys/bus/pci/devices/*; do
+        read vendor < "$dev/vendor"
+        if [ "$vendor" = "0x15b3" ]; then
+            echo "Mellanox device found at $(basename "$dev")"
+            return 0
+        fi
+    done
```

## Tests
- `tests/test_mellanox_devices_present.sh`

```diff
--- /dev/null
+++ tests/test_mellanox_devices_present.sh
@@ -0,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+DRIVER_FILE="ubuntu24.04/nvidia-driver"
+
+if grep -F '    devices_found=0' "$DRIVER_FILE"; then
+    echo "FAIL: unused devices_found variable still present" >&2
+    exit 1
+fi
+
+if ! grep -F 'read vendor < "$dev/vendor"' "$DRIVER_FILE"; then
+    echo "FAIL: device vendor path is not quoted" >&2
+    exit 1
+fi
+
+echo "PASS: mellanox helper has no dead code and quotes device path"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).