### PR TITLE
fix: deprecated '[ ! -z ... ]' instead of '-n'

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -65,7 +65,7 @@ _cleanup_package_cache() {
 }
 
 _update_ca_certificates() {
-    if [ ! -z "$(ls -A /usr/local/share/ca-certificates)" ]; then
+    if [ -n "$(ls -A /usr/local/share/ca-certificates)" ]; then
         update-ca-certificates
     fi
 }
@@ -298,7 +298,7 @@ _load_driver() {
 
     if [[ "$set_fw_path" == "true" ]]; then
         echo "Configuring the following firmware search path in '$fw_path_config_file': $nv_fw_search_path"
-        if [[ ! -z $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
+        if [[ -n $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
             echo "WARNING: A search path is already configured in $fw_path_config_file"
             echo "         Retaining the current configuration"
         else


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: deprecated '[ ! -z ... ]' instead of '-n'.

## Changes
- `ubuntu24.04/nvidia-driver`: deprecated '[ ! -z ... ]' instead of '-n'.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -76,7 +76,7 @@ _cleanup_package_cache() {
 }
 
 _update_ca_certificates() {
-    if [ ! -z "$(ls -A /usr/local/share/ca-certificates)" ]; then
+    if [ -n "$(ls -A /usr/local/share/ca-certificates)" ]; then
         update-ca-certificates
     fi
 }
@@ -401,7 +401,7 @@ _load_driver() {
     if [[ "$set_fw_path" == "true" ]]; then
         echo "Configuring the following firmware search path in '$fw_path_config_file': $nv_fw_search_path"
-        if [[ ! -z $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
+        if [[ -n $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
             echo "WARNING: A search path is already configured in $fw_path_config_file"
             echo "         Retaining the current configuration"
         else
```

## Tests
- `tests/test_no_deprecated_not_z.sh`

```diff
--- /dev/null
+++ tests/test_no_deprecated_not_z.sh
@@ -0,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+DRIVER_FILE="ubuntu24.04/nvidia-driver"
+
+if grep -F '[ ! -z ' "$DRIVER_FILE"; then
+    echo "FAIL: deprecated '[ ! -z ... ]' still present" >&2
+    exit 1
+fi
+
+if grep -F '[[ ! -z ' "$DRIVER_FILE"; then
+    echo "FAIL: deprecated '[[ ! -z ... ]]' still present" >&2
+    exit 1
+fi
+
+echo "PASS: no deprecated '[ ! -z ... ]' tests"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).