### PR TITLE
fix: _install_driver uses relative path to .run file

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -477,7 +477,7 @@ _install_driver() {
     fi
 
     # Install the NVIDIA driver in one step
-    sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
+    sh /drivers/NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
                     --ui=none \
                     --no-drm \
                     --no-nouveau-check \


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: _install_driver uses relative path to .run file.

## Changes
- `ubuntu24.04/nvidia-driver`: _install_driver uses relative path to .run file.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,1 +1,1 @@
-    sh NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
+    sh /drivers/NVIDIA-Linux-$DRIVER_ARCH-$DRIVER_VERSION.run --silent \
```

## Tests
- `ubuntu24.04/tests/test_nvidia_driver.sh`

```diff
diff --git a/ubuntu24.04/tests/test_nvidia_driver.sh b/ubuntu24.04/tests/test_nvidia_driver.sh
new file mode 100755
index 0000000..abcdef1
--- /dev/null
+++ b/ubuntu24.04/tests/test_nvidia_driver.sh
@@ -0,0 +1,46 @@
+#!/bin/bash
+# Minimal regression tests for ubuntu24.04/nvidia-driver
+# Run with: bash ubuntu24.04/tests/test_nvidia_driver.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER_SCRIPT="${SCRIPT_DIR}/../nvidia-driver"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+test_init_accepts_kernel_and_tag_options() {
+    local getopt_line
+    getopt_line=$(grep -E '^ *init\) options=' "${DRIVER_SCRIPT}")
+    [[ "${getopt_line}" == *"-o am:k:t:"* ]] || fail "init getopt missing short options -k and -t"
+    [[ "${getopt_line}" == *"kernel:"* ]] || fail "init getopt missing long option kernel:"
+    [[ "${getopt_line}" == *"tag:"* ]] || fail "init getopt missing long option tag:"
+}
+
+test_install_driver_uses_absolute_runfile_path() {
+    local func_body
+    func_body=$(sed -n '/^_install_driver() {/,/^}/p' "${DRIVER_SCRIPT}")
+    if echo "${func_body}" | grep -qE 'sh +NVIDIA-Linux-'; then
+        if ! echo "${func_body}" | grep -qE '(cd /drivers|/drivers/NVIDIA-Linux-)'; then
+            fail "_install_driver uses a relative path to the .run file without changing to /drivers"
+        fi
+    fi
+}
+
+test_kernel_module_type_installer_argument() {
+    local func_body
+    func_body=$(sed -n '/^_install_driver() {/,/^}/p' "${DRIVER_SCRIPT}")
+    if echo "${func_body}" | grep -q 'install_args+=("-m=${kernel_type}")'; then
+        fail "nvidia-installer kernel module type argument uses invalid -m=value syntax"
+    fi
+}
+
+test_init_accepts_kernel_and_tag_options
+test_install_driver_uses_absolute_runfile_path
+test_kernel_module_type_installer_argument
+
+echo "All tests passed"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).