### PR TITLE
fix: reload_nvidia_peermem uses 'sleep inf' and trap after sleep

### DIFF
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -813,14 +813,14 @@ reload_nvidia_peermem() {
     # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
     if [ -f /sys/module/nvidia_peermem/refcnt ]; then
         echo "nvidia-peermem module already loaded, skipping modprobe"
-        sleep inf
         trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+        sleep infinity
     fi
     if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
         if [ -f /sys/module/nvidia_peermem/refcnt ]; then
             echo "successfully loaded nvidia-peermem module, now waiting for signal"
-            sleep inf
             trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+            sleep infinity
         fi
     fi
     echo "failed to load nvidia-peermem module"


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu24.04/nvidia-driver`: reload_nvidia_peermem uses 'sleep inf' and trap after sleep.

## Changes
- `ubuntu24.04/nvidia-driver`: reload_nvidia_peermem uses 'sleep inf' and trap after sleep.

## Details
```diff
--- a/ubuntu24.04/nvidia-driver
+++ b/ubuntu24.04/nvidia-driver
@@ -1,33 +1,33 @@
-reload_nvidia_peermem() {
-    if [ "$USE_HOST_MOFED" = "true" ]; then
-        until  lsmod | grep mlx5_core > /dev/null 2>&1 && [ -f /run/nvidia/validations/.driver-ctr-ready ];
-        do
-            echo "waiting for mellanox ofed and nvidia drivers to be installed"
-            sleep 10
-        done
-    else
-        # use driver readiness flag created by MOFED container
-        until  [ -f /run/mellanox/drivers/.driver-ready ] && [ -f /run/nvidia/validations/.driver-ctr-ready ];
-        do
-            echo "waiting for mellanox ofed and nvidia drivers to be installed"
-            sleep 10
-        done
-    fi
-    # get any parameters provided for nvidia-peermem
-    _get_module_params && set +o nounset
-    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
-    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-        echo "nvidia-peermem module already loaded, skipping modprobe"
-        sleep inf
-        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-    fi
-    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
-        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-            echo "successfully loaded nvidia-peermem module, now waiting for signal"
-            sleep inf
-            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-        fi
-    fi
-    echo "failed to load nvidia-peermem module"
-    exit 1
-}
+reload_nvidia_peermem() {
+    if [ "$USE_HOST_MOFED" = "true" ]; then
+        until  lsmod | grep mlx5_core > /dev/null 2>&1 && [ -f /run/nvidia/validations/.driver-ctr-ready ];
+        do
+            echo "waiting for mellanox ofed and nvidia drivers to be installed"
+            sleep 10
+        done
+    else
+        # use driver readiness flag created by MOFED container
+        until  [ -f /run/mellanox/drivers/.driver-ready ] && [ -f /run/nvidia/validations/.driver-ctr-ready ];
+        do
+            echo "waiting for mellanox ofed and nvidia drivers to be installed"
+            sleep 10
+        done
+    fi
+    # get any parameters provided for nvidia-peermem
+    _get_module_params && set +o nounset
+    # If nvidia-peermem is already loaded (e.g. fast-path restart), skip modprobe
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        echo "nvidia-peermem module already loaded, skipping modprobe"
+        trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+        sleep infinity
+    fi
+    if chroot /run/nvidia/driver modprobe nvidia-peermem "${NVIDIA_PEERMEM_MODULE_PARAMS[@]}"; then
+        if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+            echo "successfully loaded nvidia-peermem module, now waiting for signal"
+            trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
+            sleep infinity
+        fi
+    fi
+    echo "failed to load nvidia-peermem module"
+    exit 1
+}
```

## Tests
- `tests/test_nvidia-driver.sh`

```diff
--- /dev/null
+++ tests/test_nvidia-driver.sh
@@ -0,0 +1,35 @@
+#!/bin/bash
+# Minimal regression tests for ubuntu24.04/nvidia-driver
+# Usage: bash tests/test_nvidia-driver.sh [path-to-nvidia-driver]
+set -eu
+
+script="${1:-ubuntu24.04/nvidia-driver}"
+fail=0
+
+test_reload_peermem_wait() {
+    if grep -q 'sleep inf' "$script"; then
+        echo "FAIL: 'sleep inf' is not portable; use 'sleep infinity'"
+        fail=1
+    fi
+
+    awk '/^reload_nvidia_peermem\(\)/,/^\}/' "$script" > /tmp/reload_peermem_func.txt
+    while grep -q 'sleep' /tmp/reload_peermem_func.txt; do
+        line=$(grep -n 'sleep' /tmp/reload_peermem_func.txt | head -1 | cut -d: -f1)
+        prev=$((line - 1))
+        if ! sed -n "${prev}p" /tmp/reload_peermem_func.txt | grep -q 'trap'; then
+            echo "FAIL: reload_nvidia_peermem sleeps without a preceding signal trap"
+            fail=1
+        fi
+        sed -i "${line}d" /tmp/reload_peermem_func.txt
+    done
+}
+
+test_reload_peermem_wait
+
+# --- next test insertion point ---
+
+exit $fail
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).