### PR TITLE
fix: set -e bypasses vgpu-util match error handler

### DIFF
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -635,8 +635,7 @@ _find_vgpu_driver_version() {
     echo "found $NUM_VGPU_DEVICES vgpu devices on host"
 
     # find compatible guest driver using drive catalog
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
+    if ! version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml); then
         echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
         return 1
     fi


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu22.04/nvidia-driver`: set -e bypasses vgpu-util match error handler.

## Changes
- `ubuntu22.04/nvidia-driver`: set -e bypasses vgpu-util match error handler.

## Details
```diff
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -1,2 +1,1 @@
-    version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml)
-    if [ $? -ne 0 ]; then
+    if ! version=$(vgpu-util match -i /drivers -c /drivers/vgpuDriverCatalog.yaml); then
```

## Tests
- `tests/test_vgpu_match.sh`

```diff
--- /dev/null
+++ b/tests/test_vgpu_match.sh
@@ -0,0 +1,52 @@
+#!/bin/bash
+# Regression test: _find_vgpu_driver_version must return 1 on a failing
+# `vgpu-util match` and print an error message, even with set -e active.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER_SCRIPT="${SCRIPT_DIR}/../ubuntu22.04/nvidia-driver"
+
+if [ ! -f "$DRIVER_SCRIPT" ]; then
+    echo "ERROR: $DRIVER_SCRIPT not found"
+    exit 1
+fi
+
+func_body=$(sed -n '/^_find_vgpu_driver_version() {/,/^}/p' "$DRIVER_SCRIPT")
+if [ -z "$func_body" ]; then
+    echo "ERROR: could not extract _find_vgpu_driver_version from $DRIVER_SCRIPT"
+    exit 1
+fi
+
+output=$( (
+    set -e
+    eval "$func_body"
+
+    vgpu-util() {
+        if [ "$1" = "count" ]; then
+            echo "count=1"
+            return 0
+        fi
+        return 1
+    }
+
+    DISABLE_VGPU_VERSION_CHECK=false
+
+    # Function should return 1 when match fails.
+    if _find_vgpu_driver_version; then
+        echo "FAIL: expected _find_vgpu_driver_version to return non-zero"
+        exit 1
+    fi
+
+    echo "PASS"
+) 2>&1 )
+status=$?
+
+if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+    echo "FAIL: _find_vgpu_driver_version did not handle vgpu-util match failure"
+    echo "$output"
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).