### PR TITLE
fix: set -e bypasses vgpu-util count error handler

### DIFF
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -622,8 +622,7 @@ _find_vgpu_driver_version() {
         return 0
     fi
     # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
+    if ! count=$(vgpu-util count); then
          echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
          return 0
     fi


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu22.04/nvidia-driver`: set -e bypasses vgpu-util count error handler.

## Changes
- `ubuntu22.04/nvidia-driver`: set -e bypasses vgpu-util count error handler.

## Details
```diff
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -1,2 +1,1 @@
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
+    if ! count=$(vgpu-util count); then
```

## Tests
- `tests/test_vgpu_count.sh`

```diff
--- /dev/null
+++ b/tests/test_vgpu_count.sh
@@ -0,0 +1,54 @@
+#!/bin/bash
+# Regression test: _find_vgpu_driver_version must handle a failing
+# `vgpu-util count` gracefully (return 0 and print a message) under set -e.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER_SCRIPT="${SCRIPT_DIR}/../ubuntu22.04/nvidia-driver"
+
+if [ ! -f "$DRIVER_SCRIPT" ]; then
+    echo "ERROR: $DRIVER_SCRIPT not found"
+    exit 1
+fi
+
+func_body=$(sed -n '/^_find_vgpu_driver_version() {/,/^}/p' "$DRIVER_SCRIPT")
+if [ -z "$func_body" ]; then
+    echo "ERROR: could not extract _find_vgpu_driver_version from $DRIVER_SCRIPT"
+    exit 1
+fi
+
+output=$( (
+    set -e
+    eval "$func_body"
+
+    vgpu-util() {
+        if [ "$1" = "count" ]; then
+            return 1
+        fi
+        echo "version=123.45"
+        return 0
+    }
+
+    DISABLE_VGPU_VERSION_CHECK=false
+    DRIVER_VERSION="initial"
+
+    _find_vgpu_driver_version
+
+    if [ "$DRIVER_VERSION" != "initial" ]; then
+        echo "FAIL: DRIVER_VERSION was changed when count failed"
+        exit 1
+    fi
+
+    echo "PASS"
+) 2>&1 )
+status=$?
+
+if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+    echo "FAIL: _find_vgpu_driver_version did not handle vgpu-util count failure"
+    echo "$output"
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).