### PR TITLE
fix: set -e bypasses nvidia-installer fallback in auto mode

### DIFF
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -596,8 +596,7 @@ _resolve_kernel_type() {
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
     KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
+    if ! kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type); then
       echo "failed to retrieve the recommended kernel module type from nvidia-installer, falling back to using the driver branch"
       _resolve_kernel_type_from_driver_branch
       return 0


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu22.04/nvidia-driver`: set -e bypasses nvidia-installer fallback in auto mode.

## Changes
- `ubuntu22.04/nvidia-driver`: set -e bypasses nvidia-installer fallback in auto mode.

## Details
```diff
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -1,2 +1,1 @@
-    kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
-    if [ $? -ne 0 ]; then
+    if ! kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type); then
```

## Tests
- `tests/test_resolve_kernel_type.sh`

```diff
--- /dev/null
+++ b/tests/test_resolve_kernel_type.sh
@@ -0,0 +1,60 @@
+#!/bin/bash
+# Regression test: _resolve_kernel_type must fall back to branch-based
+# resolution when nvidia-installer fails, even with set -e active.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER_SCRIPT="${SCRIPT_DIR}/../ubuntu22.04/nvidia-driver"
+
+if [ ! -f "$DRIVER_SCRIPT" ]; then
+    echo "ERROR: $DRIVER_SCRIPT not found"
+    exit 1
+fi
+
+func_body=$(sed -n '/^_resolve_kernel_type() {/,/^}/p' "$DRIVER_SCRIPT")
+if [ -z "$func_body" ]; then
+    echo "ERROR: could not extract _resolve_kernel_type from $DRIVER_SCRIPT"
+    exit 1
+fi
+
+output=$( (
+    set -e
+    eval "$func_body"
+
+    nvidia-installer() { return 1; }
+
+    branch_resolver_called=0
+    _resolve_kernel_type_from_driver_branch() {
+        branch_resolver_called=1
+        [[ "${DRIVER_BRANCH}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
+    }
+
+    DRIVER_BRANCH=570
+    KERNEL_MODULE_TYPE=auto
+    KERNEL_TYPE=""
+
+    _resolve_kernel_type
+
+    if [ "$branch_resolver_called" -ne 1 ]; then
+        echo "FAIL: branch-based resolver was not invoked as fallback"
+        exit 1
+    fi
+
+    if [ "$KERNEL_TYPE" != "kernel-open" ]; then
+        echo "FAIL: expected KERNEL_TYPE=kernel-open for DRIVER_BRANCH=570, got '$KERNEL_TYPE'"
+        exit 1
+    fi
+
+    echo "PASS"
+) 2>&1 )
+status=$?
+
+if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+    echo "FAIL: _resolve_kernel_type fallback did not work under set -e"
+    echo "$output"
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).