### PR TITLE
fix: option parser iterates getopt string while shifting positional

### DIFF
--- a/tests/test-nvidia-driver-options.sh
+++ b/tests/test-nvidia-driver-options.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression test for option parsing in ubuntu22.04/nvidia-driver.
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+DRIVER_SCRIPT="${SCRIPT_DIR}/../ubuntu22.04/nvidia-driver"
+
+# Stubs for the top-level command functions so sourcing the driver script
+# does not perform real work. We rename the original definitions below so
+# these stubs remain in effect.
+init() { _print_vars; }
+update() { _print_vars; }
+reload_nvidia_peermem() { _print_vars; }
+probe_nvidia_peermem() { _print_vars; }
+usage() { echo "USAGE"; exit 1; }
+
+_print_vars() {
+    printf 'ACCEPT_LICENSE=[%s]\n' "${ACCEPT_LICENSE:-}"
+    printf 'MAX_THREADS=[%s]\n' "${MAX_THREADS:-}"
+    printf 'KERNEL_VERSION=[%s]\n' "${KERNEL_VERSION:-}"
+    printf 'PRIVATE_KEY=[%s]\n' "${PRIVATE_KEY:-}"
+    printf 'PACKAGE_TAG=[%s]\n' "${PACKAGE_TAG:-}"
+}
+
+export TARGETARCH=amd64
+export DRIVER_VERSION=570.00
+
+run() {
+    local expected="$1"; shift
+    local output
+    output=$(
+        # Rename the original command/usage function definitions so that
+        # our stubs above take effect when the driver script is sourced.
+        source <(
+            sed -e 's/^init() {/init_old() {/' \
+                -e 's/^update() {/update_old() {/' \
+                -e 's/^reload_nvidia_peermem() {/reload_nvidia_peermem_old() {/' \
+                -e 's/^probe_nvidia_peermem() {/probe_nvidia_peermem_old() {/' \
+                -e 's/^usage() {/usage_old() {/' \
+                "${DRIVER_SCRIPT}"
+        ) "$@" 2>&1
+    ) || true
+    if [ "$output" != "$expected" ]; then
+        echo "FAIL: $*"
+        echo "Expected:"
+        echo "$expected"
+        echo "Got:"
+        echo "$output"
+        exit 1
+    fi
+}
+
+run 'ACCEPT_LICENSE=[yes]
+MAX_THREADS=[8]
+KERNEL_VERSION=[]
+PRIVATE_KEY=[]
+PACKAGE_TAG=[]' init -a -m 8
+
+run 'ACCEPT_LICENSE=[]
+MAX_THREADS=[-a]
+KERNEL_VERSION=[]
+PRIVATE_KEY=[]
+PACKAGE_TAG=[]' init -m '-a'
+
+run 'ACCEPT_LICENSE=[]
+MAX_THREADS=[]

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -990,14 +990,15 @@ KERNEL_VERSION=$(uname -r)
 PRIVATE_KEY=""
 PACKAGE_TAG=""
 
-for opt in ${options}; do
-    case "$opt" in
+while [ $# -gt 0 ]; do
+    case "$1" in
     -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
     -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
     -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
     -s | --sign) PRIVATE_KEY=$2; shift 2 ;;
     -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
     --) shift; break ;;
+    *) usage ;;
     esac
 done
 if [ $# -ne 0 ]; then


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu22.04/nvidia-driver`: option parser iterates getopt string while shifting positional.

## Changes
- `ubuntu22.04/nvidia-driver`: option parser iterates getopt string while shifting positional.

## Details
```diff
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -1,10 +1,11 @@
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
-    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
-    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
-    -s | --sign) PRIVATE_KEY=$2; shift 2 ;;
-    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
-    --) shift; break ;;
-    esac
-done
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
+    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
+    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
+    -s | --sign) PRIVATE_KEY=$2; shift 2 ;;
+    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+    --) shift; break ;;
+    *) usage ;;
+    esac
+done
```

## Tests
- `tests/test-nvidia-driver-options.sh`

```diff
diff --git a/tests/test-nvidia-driver-options.sh b/tests/test-nvidia-driver-options.sh
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test-nvidia-driver-options.sh
@@ -0,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression test for option parsing in ubuntu22.04/nvidia-driver.
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+DRIVER_SCRIPT="${SCRIPT_DIR}/../ubuntu22.04/nvidia-driver"
+
+# Stubs for the top-level command functions so sourcing the driver script
+# does not perform real work. We rename the original definitions below so
+# these stubs remain in effect.
+init() { _print_vars; }
+update() { _print_vars; }
+reload_nvidia_peermem() { _print_vars; }
+probe_nvidia_peermem() { _print_vars; }
+usage() { echo "USAGE"; exit 1; }
+
+_print_vars() {
+    printf 'ACCEPT_LICENSE=[%s]\n' "${ACCEPT_LICENSE:-}"
+    printf 'MAX_THREADS=[%s]\n' "${MAX_THREADS:-}"
+    printf 'KERNEL_VERSION=[%s]\n' "${KERNEL_VERSION:-}"
+    printf 'PRIVATE_KEY=[%s]\n' "${PRIVATE_KEY:-}"
+    printf 'PACKAGE_TAG=[%s]\n' "${PACKAGE_TAG:-}"
+}
+
+export TARGETARCH=amd64
+export DRIVER_VERSION=570.00
+
+run() {
+    local expected="$1"; shift
+    local output
+    output=$(
+        # Rename the original command/usage function definitions so that
+        # our stubs above take effect when the driver script is sourced.
+        source <(
+            sed -e 's/^init() {/init_old() {/' \
+                -e 's/^update() {/update_old() {/' \
+                -e 's/^reload_nvidia_peermem() {/reload_nvidia_peermem_old() {/' \
+                -e 's/^probe_nvidia_peermem() {/probe_nvidia_peermem_old() {/' \
+                -e 's/^usage() {/usage_old() {/' \
+                "${DRIVER_SCRIPT}"
+        ) "$@" 2>&1
+    ) || true
+    if [ "$output" != "$expected" ]; then
+        echo "FAIL: $*"
+        echo "Expected:"
+        echo "$expected"
+        echo "Got:"
+        echo "$output"
+        exit 1
+    fi
+}
+
+run 'ACCEPT_LICENSE=[yes]
+MAX_THREADS=[8]
+KERNEL_VERSION=[]
+PRIVATE_KEY=[]
+PACKAGE_TAG=[]' init -a -m 8
+
+run 'ACCEPT_LICENSE=[]
+MAX_THREADS=[-a]
+KERNEL_VERSION=[]
+PRIVATE_KEY=[]
+PACKAGE_TAG=[]' init -m '-a'
+
+run 'ACCEPT_LICENSE=[]
+MAX_THREADS=[]
+KERNEL_VERSION=[5.4.0]
+PRIVATE_KEY=[]
+PACKAGE_TAG=[--]' update -t '--' -k 5.4.0
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).