### PR TITLE
fix: quote command substitution in firmware path check

### DIFF
--- a/tests/test_fw_path_quoting.sh
+++ b/tests/test_fw_path_quoting.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Regression test: the firmware path occupancy check must quote its command
+# substitution so multi-word contents do not break the [[ ]] test.
+set -euo pipefail
+
+driver_file="ubuntu22.04/nvidia-driver"
+
+if grep -q '\[\[ ! -z $(grep' "$driver_file"; then
+    echo "FAIL: unquoted command substitution in [[ ]] test remains"
+    exit 1
+fi
+

--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -357,7 +357,7 @@ _load_driver() {
 
     if [[ "$set_fw_path" == "true" ]]; then
         echo "Configuring the following firmware search path in '$fw_path_config_file': $nv_fw_search_path"
-        if [[ ! -z $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
+        if grep -q '[^[:space:]]' "$fw_path_config_file"; then
             echo "WARNING: A search path is already configured in $fw_path_config_file"
             echo "         Retaining the current configuration"
         else


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu22.04/nvidia-driver`: quote command substitution in firmware path check.

## Changes
- `ubuntu22.04/nvidia-driver`: quote command substitution in firmware path check.

## Details
```diff
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -1,1 +1,1 @@
-        if [[ ! -z $(grep '[^[:space:]]' $fw_path_config_file) ]]; then
+        if grep -q '[^[:space:]]' "$fw_path_config_file"; then
```

## Tests
- `tests/test_fw_path_quoting.sh`

```diff
--- /dev/null
+++ b/tests/test_fw_path_quoting.sh
@@ -0,0 +1,12 @@
+#!/bin/bash
+# Regression test: the firmware path occupancy check must quote its command
+# substitution so multi-word contents do not break the [[ ]] test.
+set -euo pipefail
+
+driver_file="ubuntu22.04/nvidia-driver"
+
+if grep -q '\[\[ ! -z $(grep' "$driver_file"; then
+    echo "FAIL: unquoted command substitution in [[ ]] test remains"
+    exit 1
+fi
+
+echo "PASS: firmware path check uses quoted substitution"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).