### PR TITLE
fix: kernel update hook only exports DRIVER_VERSION

### DIFF
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -568,7 +568,13 @@ trap 'echo "ERROR: Failed to update the NVIDIA driver" >&2; exit 0' ERR
 
 NVIDIA_DRIVER_PID=$(< /run/nvidia/nvidia-driver.pid)
 
-export "$(grep -z DRIVER_VERSION /proc/${NVIDIA_DRIVER_PID}/environ)"
+# Mirror the driver container's environment; the update command is started by
+# the host kernel postinst context and would otherwise lack required variables
+# such as TARGETARCH and KERNEL_TYPE.
+while IFS= read -r -d '' var; do
+    [[ -n "${var}" ]] && export "${var}"
+done < /proc/${NVIDIA_DRIVER_PID}/environ
+
 nsenter -t "${NVIDIA_DRIVER_PID}" -m -- nvidia-driver update --kernel "$1"
 EOF
     chmod +x ${KERNEL_UPDATE_HOOK}
@@ -592,9 +598,9 @@ _shutdown() {
 # When 'auto' is configured, we use the nvidia-installer to recommend the module type to install.
 _resolve_kernel_type() {
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
-    KERNEL_TYPE=kernel
+    export KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
-    KERNEL_TYPE=kernel-open
+    export KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
     kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
     if [ $? -ne 0 ]; then
@@ -602,7 +608,7 @@ _resolve_kernel_type() {
       _resolve_kernel_type_from_driver_branch
       return 0
     fi
-    [[ "${kernel_module_type}" == "open" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
+    [[ "${kernel_module_type}" == "open" ]] && export KERNEL_TYPE=kernel-open || export KERNEL_TYPE=kernel
   else
     echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}"
     return 1
@@ -610,7 +616,7 @@ _resolve_kernel_type() {
 }
 
 _resolve_kernel_type_from_driver_branch() {
-  [[ "${DRIVER_BRANCH}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
+  [[ "${DRIVER_BRANCH}" -lt 560 ]] && export KERNEL_TYPE=kernel || export KERNEL_TYPE=kernel-open
 }
 
 _find_vgpu_driver_version() {


### PR DESCRIPTION
This PR addresses the following issue in `ubuntu22.04/nvidia-driver`: kernel update hook only exports DRIVER_VERSION.

## Changes
- `ubuntu22.04/nvidia-driver`: kernel update hook only exports DRIVER_VERSION.

## Details
```diff
--- a/ubuntu22.04/nvidia-driver
+++ b/ubuntu22.04/nvidia-driver
@@ -455,9 +455,9 @@
 _resolve_kernel_type() {
   if [ "${KERNEL_MODULE_TYPE}" == "proprietary" ]; then
-    KERNEL_TYPE=kernel
+    export KERNEL_TYPE=kernel
   elif [ "${KERNEL_MODULE_TYPE}" == "open" ]; then
-    KERNEL_TYPE=kernel-open
+    export KERNEL_TYPE=kernel-open
   elif [ "${KERNEL_MODULE_TYPE}" == "auto" ]; then
     kernel_module_type=$(nvidia-installer --print-recommended-kernel-module-type)
     if [ $? -ne 0 ]; then
@@ -466,7 +466,7 @@
       _resolve_kernel_type_from_driver_branch
       return 0
     fi
-    [[ "${kernel_module_type}" == "open" ]] && KERNEL_TYPE=kernel-open || KERNEL_TYPE=kernel
+    [[ "${kernel_module_type}" == "open" ]] && export KERNEL_TYPE=kernel-open || export KERNEL_TYPE=kernel
   else
     echo "invalid value for the KERNEL_MODULE_TYPE variable: ${KERNEL_MODULE_TYPE}"
     return 1
@@ -474,7 +474,7 @@
 
 _resolve_kernel_type_from_driver_branch() {
-  [[ "${DRIVER_BRANCH}" -lt 560 ]] && KERNEL_TYPE=kernel || KERNEL_TYPE=kernel-open
+  [[ "${DRIVER_BRANCH}" -lt 560 ]] && export KERNEL_TYPE=kernel || export KERNEL_TYPE=kernel-open
 }
 
 _find_vgpu_driver_version() {
@@ -724,9 +724,13 @@
     echo "Writing kernel update hook..."
     cat > ${KERNEL_UPDATE_HOOK} <<'EOF'
 #!/bin/bash
 
 set -eu
 trap 'echo "ERROR: Failed to update the NVIDIA driver" >&2; exit 0' ERR
 
 NVIDIA_DRIVER_PID=$(< /run/nvidia/nvidia-driver.pid)
 
-export "$(grep -z DRIVER_VERSION /proc/${NVIDIA_DRIVER_PID}/environ)"
+# Mirror the driver container's environment; the update command is started by
+# the host kernel postinst context and would otherwise lack required variables
+# such as TARGETARCH and KERNEL_TYPE.
+while IFS= read -r -d '' var; do
+    [[ -n "${var}" ]] && export "${var}"
+done < /proc/${NVIDIA_DRIVER_PID}/environ
+
 nsenter -t "${NVIDIA_DRIVER_PID}" -m -- nvidia-driver update --kernel "$1"
 EOF
     chmod +x ${KERNEL_UPDATE_HOOK}
 }
```

## Tests
- `tests/test_update_hook_env.sh`

```diff
--- /dev/null
+++ tests/test_update_hook_env.sh
@@ -0,0 +1,55 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DRIVER="$SCRIPT_DIR/ubuntu22.04/nvidia-driver"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Test 1: KERNEL_TYPE must be exported so the hook can pass it to the update.
+awk '/^_resolve_kernel_type/,/^}/' "$DRIVER" > "$tmp/resolve.sh"
+awk '/^_resolve_kernel_type_from_driver_branch/,/^}/' "$DRIVER" >> "$tmp/resolve.sh"
+
+cat > "$tmp/run_resolve.sh" <<EOF
+set -eu
+source "$tmp/resolve.sh"
+KERNEL_MODULE_TYPE=proprietary
+DRIVER_BRANCH=550
+_resolve_kernel_type
+if ! grep -z 'KERNEL_TYPE=kernel' /proc/self/environ >/dev/null; then
+    echo "FAIL: KERNEL_TYPE is not exported to the driver process environment"
+    exit 1
+fi
+echo "PASS_EXPORT"
+EOF
+
+if ! bash "$tmp/run_resolve.sh"; then
+    echo "FAIL: KERNEL_TYPE export test failed"
+    exit 1
+fi
+
+# Test 2: the generated kernel update hook must source the driver environment,
+# not just DRIVER_VERSION.
+awk '/^_write_kernel_update_hook/,/^}/' "$DRIVER" > "$tmp/hook.sh"
+
+hook_dir="$tmp/hookdir"
+mkdir -p "$hook_dir"
+KERNEL_UPDATE_HOOK="$hook_dir/update-nvidia-driver"
+
+cat > "$tmp/run_hook.sh" <<EOF
+set -eu
+source "$tmp/hook.sh"
+KERNEL_UPDATE_HOOK="$KERNEL_UPDATE_HOOK"
+_write_kernel_update_hook
+EOF
+
+bash "$tmp/run_hook.sh"
+
+if ! grep -q 'while IFS= read -r -d' "$KERNEL_UPDATE_HOOK"; then
+    echo "FAIL: kernel update hook does not source the driver environment"
+    exit 1
+fi
+
+echo "test_update_hook_env: PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).