### PR TITLE
fix: _create_driver_package never builds nvidia-uvm.ko

### DIFF
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -246,7 +246,7 @@ _create_driver_package() (
         fi
     fi
 
-    make -s -j ${MAX_THREADS} SYSSRC=/lib/modules/${KERNEL_VERSION}/build nv-linux.o nv-modeset-linux.o > /dev/null
+    make -s -j ${MAX_THREADS} SYSSRC=/lib/modules/${KERNEL_VERSION}/build nv-linux.o nv-modeset-linux.o nvidia-uvm.ko > /dev/null
 
     echo "Relinking NVIDIA driver kernel modules..."
     rm -f nvidia.ko nvidia-modeset.ko

--- a/test_create_driver_package.sh
+++ b/test_create_driver_package.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Regression test: the _create_driver_package function must list nvidia-uvm.ko
+# as a make target because it is signed and packed later in the same function.
+func_body=$(sed -n '/^_create_driver_package()/,/^}/p' rhel9/nvidia-driver)
+make_line=$(printf '%s\n' "$func_body" | grep -E '^\s+make -s -j .* SYSSRC=')
+
+if [ -z "$make_line" ]; then
+    echo "FAIL: could not find the make invocation in _create_driver_package"
+    exit 1
+fi
+
+if printf '%s\n' "$make_line" | grep -q 'nvidia-uvm.ko'; then
+    echo "PASS: _create_driver_package builds nvidia-uvm.ko"
+else
+    echo "FAIL: _create_driver_package does not build nvidia-uvm.ko"


### PR DESCRIPTION
This PR addresses the following issue in `rhel9/nvidia-driver`: _create_driver_package never builds nvidia-uvm.ko.

## Changes
- `rhel9/nvidia-driver`: _create_driver_package never builds nvidia-uvm.ko.

## Details
```diff
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -1,1 +1,1 @@
-    make -s -j ${MAX_THREADS} SYSSRC=/lib/modules/${KERNEL_VERSION}/build nv-linux.o nv-modeset-linux.o > /dev/null
+    make -s -j ${MAX_THREADS} SYSSRC=/lib/modules/${KERNEL_VERSION}/build nv-linux.o nv-modeset-linux.o nvidia-uvm.ko > /dev/null
```

## Tests
- `rhel9/test_create_driver_package.sh`

```diff
--- /dev/null
+++ rhel9/test_create_driver_package.sh
@@ -0,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Regression test: the _create_driver_package function must list nvidia-uvm.ko
+# as a make target because it is signed and packed later in the same function.
+func_body=$(sed -n '/^_create_driver_package()/,/^}/p' rhel9/nvidia-driver)
+make_line=$(printf '%s\n' "$func_body" | grep -E '^\s+make -s -j .* SYSSRC=')
+
+if [ -z "$make_line" ]; then
+    echo "FAIL: could not find the make invocation in _create_driver_package"
+    exit 1
+fi
+
+if printf '%s\n' "$make_line" | grep -q 'nvidia-uvm.ko'; then
+    echo "PASS: _create_driver_package builds nvidia-uvm.ko"
+else
+    echo "FAIL: _create_driver_package does not build nvidia-uvm.ko"
+    echo "Found: $make_line"
+    exit 1
+fi
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).