### PR TITLE
fix: replace fragile option parsing loop with positional loop

### DIFF
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -1045,8 +1045,8 @@ KERNEL_VERSION=$(uname -r)
 PRIVATE_KEY=""
 PACKAGE_TAG=""
 
-for opt in ${options}; do
-    case "$opt" in
+while [ $# -gt 0 ]; do
+    case "$1" in
     -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
     -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
     -m | --max-threads) MAX_THREADS=$2; shift 2 ;;


### PR DESCRIPTION
This PR addresses the following issue in `rhel9/nvidia-driver`: replace fragile option parsing loop with positional loop.

## Changes
- `rhel9/nvidia-driver`: replace fragile option parsing loop with positional loop.

## Details
```diff
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -1,10 +1,10 @@
-for opt in ${options}; do
-    case "$opt" in
-    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
-    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
-    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
-    -s | --sign) PRIVATE_KEY=$2; shift 2 ;;
-    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
-    --) shift; break ;;
-    esac
-done
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -a | --accept-license) ACCEPT_LICENSE="yes"; shift 1 ;;
+    -k | --kernel) KERNEL_VERSION=$2; shift 2 ;;
+    -m | --max-threads) MAX_THREADS=$2; shift 2 ;;
+    -s | --sign) PRIVATE_KEY=$2; shift 2 ;;
+    -t | --tag) PACKAGE_TAG=$2; shift 2 ;;
+    --) shift; break ;;
+    esac
+done
```

## Tests
- `tests/test_option_parsing.sh`

```diff
new file mode 100755
--- /dev/null
+++ tests/test_option_parsing.sh
@@ -0,0 +1,11 @@
+#!/bin/bash
+set -eu
+FILE=rhel9/nvidia-driver
+if grep -F 'for opt in ${options}' $FILE; then
+  echo FAIL: fragile for/opt parsing remains; exit 1
+fi
+if ! grep -F 'while [ $# -gt 0 ]' $FILE; then
+  echo FAIL: while-based parsing not found; exit 1
+fi
+echo PASS
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).