### PR TITLE
fix: handle yum failures when resolving kernel version

### DIFF
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -81,8 +81,12 @@ _resolve_rhel_version() {
 # Resolve the kernel version to the form major.minor.patch-revision.
 _resolve_kernel_version() {
     echo "Resolving Linux kernel version..."
-    local version=$(yum -q list available --showduplicates kernel-headers |
-      awk -v arch=$(uname -m) 'NR>1 {print $2"."arch}' | tac | grep -E -m1 "^${KERNEL_VERSION/latest/.*}")
+    local version
+    if ! version=$(yum -q list available --showduplicates kernel-headers |
+      awk -v arch=$(uname -m) 'NR>1 {print $2"."arch}' | tac | grep -E -m1 "^${KERNEL_VERSION/latest/.*}"); then
+        echo "Could not resolve Linux kernel version" >&2
+        return 1
+    fi
 
     if [ -z "${version}" ]; then
         echo "Could not resolve Linux kernel version" >&2

--- a/tests/test_resolve_kernel_version_yum_failure.sh
+++ b/tests/test_resolve_kernel_version_yum_failure.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cp rhel8/nvidia-driver "$tmp/lib.sh"
+sed -i '/^usage() {/,$d' "$tmp/lib.sh"
+: > "$tmp/common.sh"
+
+export DRIVER_VERSION="550.54.15"
+export TARGETARCH="amd64"
+export KERNEL_VERSION="4.18.0-513.el8_9.x86_64"
+export DRIVER_BRANCH=550
+
+set +e
+output=$(
+  cd "$tmp"
+  . ./lib.sh >/dev/null 2>&1
+  yum() { return 1; }
+  if ! _resolve_kernel_version 2>&1; then
+    echo "HANDLED"
+  fi
+  echo "MARKER"
+)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+  echo "FAIL: _resolve_kernel_version caused an early exit (status=$status)"
+  exit 1
+fi
+if [[ "$output" == *"Could not resolve Linux kernel version"* && "$output" == *"HANDLED"* && "$output" == *"MARKER"* ]]; then
+  echo "PASS: _resolve_kernel_version handles yum failure"
+else


### PR DESCRIPTION
This PR addresses the following issue in `rhel8/nvidia-driver`: handle yum failures when resolving kernel version.

## Changes
- `rhel8/nvidia-driver`: handle yum failures when resolving kernel version.

## Details
```diff
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -1,7 +1,11 @@
-    local version=$(yum -q list available --showduplicates kernel-headers |
-      awk -v arch=$(uname -m) 'NR>1 {print $2"."arch}' | tac | grep -E -m1 "^${KERNEL_VERSION/latest/.*}")
-
-    if [ -z "${version}" ]; then
-        echo "Could not resolve Linux kernel version" >&2
-        return 1
-    fi
+    local version
+    if ! version=$(yum -q list available --showduplicates kernel-headers |
+      awk -v arch=$(uname -m) 'NR>1 {print $2"."arch}' | tac | grep -E -m1 "^${KERNEL_VERSION/latest/.*}"); then
+        echo "Could not resolve Linux kernel version" >&2
+        return 1
+    fi
+
+    if [ -z "${version}" ]; then
+        echo "Could not resolve Linux kernel version" >&2
+        return 1
+    fi
```

## Tests
- `tests/test_resolve_kernel_version_yum_failure.sh`

```diff
diff --git a/tests/test_resolve_kernel_version_yum_failure.sh b/tests/test_resolve_kernel_version_yum_failure.sh
new file mode 100755
--- /dev/null
+++ b/tests/test_resolve_kernel_version_yum_failure.sh
@@ -0,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cp rhel8/nvidia-driver "$tmp/lib.sh"
+sed -i '/^usage() {/,$d' "$tmp/lib.sh"
+: > "$tmp/common.sh"
+
+export DRIVER_VERSION="550.54.15"
+export TARGETARCH="amd64"
+export KERNEL_VERSION="4.18.0-513.el8_9.x86_64"
+export DRIVER_BRANCH=550
+
+set +e
+output=$(
+  cd "$tmp"
+  . ./lib.sh >/dev/null 2>&1
+  yum() { return 1; }
+  if ! _resolve_kernel_version 2>&1; then
+    echo "HANDLED"
+  fi
+  echo "MARKER"
+)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+  echo "FAIL: _resolve_kernel_version caused an early exit (status=$status)"
+  exit 1
+fi
+if [[ "$output" == *"Could not resolve Linux kernel version"* && "$output" == *"HANDLED"* && "$output" == *"MARKER"* ]]; then
+  echo "PASS: _resolve_kernel_version handles yum failure"
+else
+  echo "FAIL: unexpected output: $output"
+  exit 1
+fi
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).