### PR TITLE
fix: rmmod unloads nvidia before dependent nvidia-peermem

### DIFF
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -510,14 +510,14 @@ _unload_driver() {
         rmmod_args+=("nvidia-uvm")
         ((++nvidia_deps))
     fi
-    if [ -f /sys/module/nvidia/refcnt ]; then
-        nvidia_refs=$(< /sys/module/nvidia/refcnt)
-        rmmod_args+=("nvidia")
-    fi
     if [ -f /sys/module/nvidia_peermem/refcnt ]; then
         nvidia_peermem_refs=$(< /sys/module/nvidia_peermem/refcnt)
         rmmod_args+=("nvidia-peermem")
         ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia/refcnt ]; then
+        nvidia_refs=$(< /sys/module/nvidia/refcnt)
+        rmmod_args+=("nvidia")
     fi
     if [ ${nvidia_refs} -gt ${nvidia_deps} ] || [ ${nvidia_uvm_refs} -gt 0 ] || [ ${nvidia_modeset_refs} -gt 0 ] || [ ${nvidia_peermem_refs} -gt 0 ]; then
         echo "Could not unload NVIDIA driver kernel modules, driver is in use" >&2

--- a/rhel8/tests/test_unload_order.sh
+++ b/rhel8/tests/test_unload_order.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+script_dir=$(dirname "$(readlink -f \"$0\")")
+driver_file=\"$script_dir/../nvidia-driver\"
+
+peermem_line=$(grep -n 'rmmod_args+=(\"nvidia-peermem\")' \"$driver_file\" | head -n1 | cut -d: -f1 || true)
+nvidia_line=$(grep -n 'rmmod_args+=(\"nvidia\")' \"$driver_file\" | head -n1 | cut -d: -f1 || true)
+
+if [[ -z \"$peermem_line\" ]] || [[ -z \"$nvidia_line\" ]]; then
+    echo \"FAIL: could not locate rmmod_args entries\"
+    exit 1
+fi
+
+if [[ \"$peermem_line\" -gt \"$nvidia_line\" ]]; then
+    echo \"FAIL: nvidia-peermem is added after nvidia in rmmod_args\"
+    exit 1
+fi
+
+echo \"PASS\"


### PR DESCRIPTION
This PR addresses the following issue in `rhel8/nvidia-driver`: rmmod unloads nvidia before dependent nvidia-peermem.

## Changes
- `rhel8/nvidia-driver`: rmmod unloads nvidia before dependent nvidia-peermem.

## Details
```diff
--- a/rhel8/nvidia-driver
+++ b/rhel8/nvidia-driver
@@ -1,14 +1,14 @@
-    if [ -f /sys/module/nvidia_uvm/refcnt ]; then
-        nvidia_uvm_refs=$(< /sys/module/nvidia_uvm/refcnt)
-        rmmod_args+=("nvidia-uvm")
-        ((++nvidia_deps))
-    fi
-    if [ -f /sys/module/nvidia/refcnt ]; then
-        nvidia_refs=$(< /sys/module/nvidia/refcnt)
-        rmmod_args+=("nvidia")
-    fi
-    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
-        nvidia_peermem_refs=$(< /sys/module/nvidia_peermem/refcnt)
-        rmmod_args+=("nvidia-peermem")
-        ((++nvidia_deps))
-    fi
+    if [ -f /sys/module/nvidia_uvm/refcnt ]; then
+        nvidia_uvm_refs=$(< /sys/module/nvidia_uvm/refcnt)
+        rmmod_args+=("nvidia-uvm")
+        ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia_peermem/refcnt ]; then
+        nvidia_peermem_refs=$(< /sys/module/nvidia_peermem/refcnt)
+        rmmod_args+=("nvidia-peermem")
+        ((++nvidia_deps))
+    fi
+    if [ -f /sys/module/nvidia/refcnt ]; then
+        nvidia_refs=$(< /sys/module/nvidia/refcnt)
+        rmmod_args+=("nvidia")
+    fi
```

## Tests
- `rhel8/tests/test_unload_order.sh`

```diff
--- /dev/null
+++ b/rhel8/tests/test_unload_order.sh
@@ -0,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+script_dir=$(dirname "$(readlink -f \"$0\")")
+driver_file=\"$script_dir/../nvidia-driver\"
+
+peermem_line=$(grep -n 'rmmod_args+=(\"nvidia-peermem\")' \"$driver_file\" | head -n1 | cut -d: -f1 || true)
+nvidia_line=$(grep -n 'rmmod_args+=(\"nvidia\")' \"$driver_file\" | head -n1 | cut -d: -f1 || true)
+
+if [[ -z \"$peermem_line\" ]] || [[ -z \"$nvidia_line\" ]]; then
+    echo \"FAIL: could not locate rmmod_args entries\"
+    exit 1
+fi
+
+if [[ \"$peermem_line\" -gt \"$nvidia_line\" ]]; then
+    echo \"FAIL: nvidia-peermem is added after nvidia in rmmod_args\"
+    exit 1
+fi
+
+echo \"PASS\"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).