### PR TITLE
fix: set -e prevents catching vgpu-util failures

### DIFF
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -681,8 +681,7 @@ _find_vgpu_driver_version() {
         return 0
     fi
     # check if vgpu devices are present
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
+    if ! count=$(vgpu-util count); then
          echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
          return 0
     fi
@@ -697,8 +696,7 @@ _find_vgpu_driver_version() {
     if [ -d "/mnt/shared-nvidia-driver-toolkit/drivers" ]; then
         drivers_path="/mnt/shared-nvidia-driver-toolkit/drivers"
     fi
-    version=$(vgpu-util match -i "${drivers_path}" -c "${drivers_path}/vgpuDriverCatalog.yaml")
-    if [ $? -ne 0 ]; then
+    if ! version=$(vgpu-util match -i "${drivers_path}" -c "${drivers_path}/vgpuDriverCatalog.yaml"); then
         echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
         return 1
     fi

--- a/test_sete_command_substitution.sh
+++ b/test_sete_command_substitution.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+# Regression test: command substitution followed by a $? check is unreachable
+# under 'set -e'. The fixed code uses 'if ! cmd=$(...); then ... fi' instead.
+
+fail=0
+if grep -A1 -E '^[[:space:]]*kernel_module_type=\$\(' rhel10/nvidia-driver | grep -q '^[[:space:]]*if \[ \$\? -ne 0 \]'; then
+    echo "FAIL: nvidia-installer result is still checked with unreachable $?"
+    fail=1
+fi
+if grep -A1 -E '^[[:space:]]*(count|version)=\$\(' rhel10/nvidia-driver | grep -q '^[[:space:]]*if \[ \$\? -ne 0 \]'; then
+    echo "FAIL: vgpu-util result is still checked with unreachable $?"
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+


### PR DESCRIPTION
This PR addresses the following issue in `rhel10/nvidia-driver`: set -e prevents catching vgpu-util failures.

## Changes
- `rhel10/nvidia-driver`: set -e prevents catching vgpu-util failures.

## Details
```diff
--- a/rhel10/nvidia-driver
+++ b/rhel10/nvidia-driver
@@ -1,21 +1,19 @@
-    count=$(vgpu-util count)
-    if [ $? -ne 0 ]; then
-         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
-         return 0
-    fi
-    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
-    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
-        # no vgpu devices found, treat as passthrough
-        return 0
-    fi
-    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
-
-    # find compatible guest driver using driver catalog
-    if [ -d "/mnt/shared-nvidia-driver-toolkit/drivers" ]; then
-        drivers_path="/mnt/shared-nvidia-driver-toolkit/drivers"
-    fi
-    version=$(vgpu-util match -i "${drivers_path}" -c "${drivers_path}/vgpuDriverCatalog.yaml")
-    if [ $? -ne 0 ]; then
-        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
-        return 1
-    fi
+    if ! count=$(vgpu-util count); then
+         echo "cannot find vgpu devices on host, pleae check /var/log/vgpu-util.log for more details..."
+         return 0
+    fi
+    NUM_VGPU_DEVICES=$(echo "$count" | awk -F= '{print $2}')
+    if [ $NUM_VGPU_DEVICES -eq 0 ]; then
+        # no vgpu devices found, treat as passthrough
+        return 0
+    fi
+    echo "found $NUM_VGPU_DEVICES vgpu devices on host"
+
+    # find compatible guest driver using driver catalog
+    if [ -d "/mnt/shared-nvidia-driver-toolkit/drivers" ]; then
+        drivers_path="/mnt/shared-nvidia-driver-toolkit/drivers"
+    fi
+    if ! version=$(vgpu-util match -i "${drivers_path}" -c "${drivers_path}/vgpuDriverCatalog.yaml"); then
+        echo "cannot find match for compatible vgpu driver from available list, please check /var/log/vgpu-util.log for more details..."
+        return 1
+    fi
```

## Tests
- `tests/test_sete_command_substitution.sh`

```diff
--- /dev/null
+++ tests/test_sete_command_substitution.sh
@@ -0,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+# Regression test: command substitution followed by a $? check is unreachable
+# under 'set -e'. The fixed code uses 'if ! cmd=$(...); then ... fi' instead.
+
+fail=0
+if grep -A1 -E '^[[:space:]]*kernel_module_type=\$\(' rhel10/nvidia-driver | grep -q '^[[:space:]]*if \[ \$\? -ne 0 \]'; then
+    echo "FAIL: nvidia-installer result is still checked with unreachable $?"
+    fail=1
+fi
+if grep -A1 -E '^[[:space:]]*(count|version)=\$\(' rhel10/nvidia-driver | grep -q '^[[:space:]]*if \[ \$\? -ne 0 \]'; then
+    echo "FAIL: vgpu-util result is still checked with unreachable $?"
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+echo "PASS: command substitution results are checked correctly"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).