### PR TITLE
Add OCI standard image labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ $(DRIVER_BUILD_TARGETS):
 				--build-arg CUDA_VERSION="$(CUDA_VERSION)" \
 				--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 				--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+				--build-arg DIST="$(DIST)" \
+				--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 				$(DOCKER_BUILD_ARGS) \
 				--file $(DOCKERFILE) \
 				$(CURDIR)/$(SUBDIR)
@@ -278,6 +280,9 @@ $(VGPU_GUEST_DRIVER_BUILD_TARGETS):
 				--build-arg DRIVER_BRANCH="$(DRIVER_BRANCH)" \
 				--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
 				--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
+				--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+				--build-arg DIST="$(DIST)" \
+				--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 				$(DOCKER_BUILD_ARGS) \
 				--file $(DOCKERFILE) \
 				$(CURDIR)/$(SUBDIR)
@@ -322,6 +327,9 @@ $(VGPU_HOST_DRIVER_BUILD_TARGETS):
 				--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 				--build-arg CUDA_VERSION="$(CUDA_VERSION)" \
 				--build-arg CUSTOM_CA_CERTS_DIR="$(CUSTOM_CA_CERTS_DIR)" \
+				--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+				--build-arg DIST="$(DIST)" \
+				--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 				$(DOCKER_BUILD_ARGS) \
 				--file $(DOCKERFILE) \
 				$(CURDIR)/vgpu-manager/$(SUBDIR)

--- a/rhel10/Dockerfile
+++ b/rhel10/Dockerfile
@@ -96,6 +96,9 @@ COPY ${PUBLIC_KEY} kernel/pubkey.x509
 ARG PRIVATE_KEY
 ARG KERNEL_VERSION=latest
 
+ARG DIST=rhel10
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -103,7 +106,17 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES

--- a/rhel10/precompiled/Dockerfile
+++ b/rhel10/precompiled/Dockerfile
@@ -189,6 +189,8 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
     && dnf clean all \
     && rm /usr/local/bin/rhsm-register
 
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -196,7 +198,17 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="${KERNEL_VERSION}-${OS_TAG}"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${KERNEL_VERSION}-${OS_TAG}"
 
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE

--- a/rhel10/precompiled/Makefile
+++ b/rhel10/precompiled/Makefile
@@ -73,6 +73,7 @@ image: rhsm-register
 		--build-arg BASE_URL=${BASE_URL} \
 		--build-arg OS_TAG=${OS_TAG} \
 		--build-arg GIT_COMMIT=${GIT_COMMIT} \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--tag ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DRIVER_VERSION}-${KERNEL_VERSION_TAG}-${OS_TAG} \
 		--progress=plain \
 		--file ${DOCKERFILE} .

--- a/rhel8/Dockerfile
+++ b/rhel8/Dockerfile
@@ -94,6 +94,9 @@ COPY ${PUBLIC_KEY} kernel/pubkey.x509
 ARG PRIVATE_KEY
 ARG KERNEL_VERSION=latest
 
+ARG DIST=rhel8
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -101,7 +104,17 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi8/ubi"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES

--- a/rhel8/precompiled/Dockerfile
+++ b/rhel8/precompiled/Dockerfile
@@ -57,6 +57,7 @@ FROM nvcr.io/nvidia/cuda:12.6.2-base-${CUDA_DIST}
 
 ARG KERNEL_VERSION=''
 ARG RHEL_VERSION=''
+ARG OS_TAG=''
 
 ARG DRIVER_TYPE=passthrough
 ENV DRIVER_TYPE=${DRIVER_TYPE}
@@ -144,6 +145,8 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
     && dnf clean all \
     && subscription-manager unregister
 
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -151,7 +154,17 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${KERNEL_VERSION}-${OS_TAG}"
 
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE

--- a/rhel8/precompiled/Makefile
+++ b/rhel8/precompiled/Makefile
@@ -53,7 +53,9 @@ image: rhsm-register
 		--build-arg DRIVER_TOOLKIT_IMAGE=${DRIVER_TOOLKIT_IMAGE} \
 		--build-arg DRIVER_TYPE=${DRIVER_TYPE} \
 		--build-arg BASE_URL=${BASE_URL} \
+		--build-arg OS_TAG=${OS_TAG} \
 		--build-arg GIT_COMMIT=${GIT_COMMIT} \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--tag ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DRIVER_VERSION}-${KERNEL_VERSION}-${OS_TAG} \
 		--progress=plain \
 		--file ${DOCKERFILE} .

--- a/rhel9/Dockerfile
+++ b/rhel9/Dockerfile
@@ -95,6 +95,9 @@ COPY ${PUBLIC_KEY} kernel/pubkey.x509
 ARG PRIVATE_KEY
 ARG KERNEL_VERSION=latest
 
+ARG DIST=rhel9
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -102,7 +105,17 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES

--- a/rhel9/precompiled/Dockerfile
+++ b/rhel9/precompiled/Dockerfile
@@ -189,6 +189,8 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
     && dnf clean all \
     && rm /usr/local/bin/rhsm-register
 
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -196,7 +198,17 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="${KERNEL_VERSION}-${OS_TAG}"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${KERNEL_VERSION}-${OS_TAG}"
 
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE

--- a/rhel9/precompiled/Makefile
+++ b/rhel9/precompiled/Makefile
@@ -73,6 +73,7 @@ image: rhsm-register
 		--build-arg BASE_URL=${BASE_URL} \
 		--build-arg OS_TAG=${OS_TAG} \
 		--build-arg GIT_COMMIT=${GIT_COMMIT} \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--tag ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DRIVER_VERSION}-${KERNEL_VERSION_TAG}-${OS_TAG} \
 		--progress=plain \
 		--file ${DOCKERFILE} .

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -108,6 +108,9 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
+ARG DIST=ubuntu22.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -115,6 +118,16 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu22.04/precompiled/Dockerfile
+++ b/ubuntu22.04/precompiled/Dockerfile
@@ -71,6 +71,9 @@ WORKDIR  /drivers
 # Remove cuda repository to avoid GPG errors
 RUN rm -f /etc/apt/sources.list.d/cuda*
 
+ARG DIST=ubuntu22.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -78,6 +81,16 @@ LABEL version="${DRIVER_BRANCH}-${KERNEL_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -97,6 +97,9 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
+ARG DIST=ubuntu24.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -104,6 +107,16 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu24.04/precompiled/Dockerfile
+++ b/ubuntu24.04/precompiled/Dockerfile
@@ -63,6 +63,9 @@ RUN mkdir -p /usr/local/repos && \
 
 WORKDIR  /drivers
 
+ARG DIST=ubuntu24.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -70,6 +73,16 @@ LABEL version="${DRIVER_BRANCH}-${KERNEL_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu26.04/Dockerfile
+++ b/ubuntu26.04/Dockerfile
@@ -88,6 +88,9 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
+ARG DIST=ubuntu26.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -95,6 +98,16 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/ubuntu26.04/precompiled/Dockerfile
+++ b/ubuntu26.04/precompiled/Dockerfile
@@ -60,6 +60,9 @@ RUN mkdir -p /usr/local/repos && \
 
 WORKDIR  /drivers
 
+ARG DIST=ubuntu26.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA Driver Container"
 LABEL name="NVIDIA Driver Container"
 LABEL vendor="NVIDIA"
@@ -67,6 +70,16 @@ LABEL version="${DRIVER_BRANCH}-${KERNEL_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA driver through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA driver through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Container"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_BRANCH}-${KERNEL_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/vgpu-manager/rhel10/Dockerfile
+++ b/vgpu-manager/rhel10/Dockerfile
@@ -40,6 +40,9 @@ RUN dnf install -y gcc make kmod pciutils procps-ng && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 
+ARG DIST=rhel10
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
@@ -47,7 +50,16 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA vGPU Manager through containers"
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA vGPU Manager through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA vGPU Manager Container"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES

--- a/vgpu-manager/rhel8/Dockerfile
+++ b/vgpu-manager/rhel8/Dockerfile
@@ -27,6 +27,9 @@ RUN dnf install -y pciutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 
+ARG DIST=rhel8
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
@@ -34,7 +37,16 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA vGPU Manager through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA vGPU Manager through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA vGPU Manager Container"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES

--- a/vgpu-manager/rhel9/Dockerfile
+++ b/vgpu-manager/rhel9/Dockerfile
@@ -40,6 +40,9 @@ RUN dnf install -y pciutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 
+ARG DIST=rhel9
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
@@ -47,7 +50,16 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA vGPU Manager through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA vGPU Manager through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA vGPU Manager Container"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 # Install / upgrade packages here that are required to resolve CVEs
 ARG CVE_UPDATES

--- a/vgpu-manager/ubuntu22.04/Dockerfile
+++ b/vgpu-manager/ubuntu22.04/Dockerfile
@@ -57,6 +57,9 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
 
+ARG DIST=ubuntu22.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
@@ -64,6 +67,15 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager (host driver) through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA vGPU Manager (host driver) through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA vGPU Manager (host driver) through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA vGPU Manager Container"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]

--- a/vgpu-manager/ubuntu24.04/Dockerfile
+++ b/vgpu-manager/ubuntu24.04/Dockerfile
@@ -51,6 +51,9 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
 # Add NGC DL license from the CUDA image
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
 
+ARG DIST=ubuntu24.04
+ARG BUILD_TIMESTAMP
+
 LABEL io.k8s.display-name="NVIDIA vGPU Manager Container"
 LABEL name="NVIDIA vGPU Manager Container"
 LABEL vendor="NVIDIA"
@@ -58,6 +61,15 @@ LABEL version="${DRIVER_VERSION}"
 LABEL vcs-ref="${GIT_COMMIT}"
 LABEL release="N/A"
 LABEL summary="Provision the NVIDIA vGPU Manager (host driver) through containers"
-LABEL description="See summary"
+LABEL description="Provision the NVIDIA vGPU Manager (host driver) through containers"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/cuda"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Provision the NVIDIA vGPU Manager (host driver) through containers"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/gpu-driver-container.git"
+LABEL org.opencontainers.image.title="NVIDIA vGPU Manager Container"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${DRIVER_VERSION}-${DIST}"
 
 ENTRYPOINT ["nvidia-driver", "init"]


### PR DESCRIPTION
This PR adds well-known OCI Image labels to the gpu-driver-container image metadata.

**Before**
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/driver:580.95.05-ubuntu24.04 | jq
{
  "org.opencontainers.image.ref.name": "ubuntu",
  "org.opencontainers.image.version": "24.04"
}
```

**After** — ubuntu24.04 image built from this branch
```
$ docker inspect --format='{{json .Config.Labels}}' nvidia/driver:580.178.04-ubuntu24.04 | jq
{
  "description": "Provision the NVIDIA driver through containers",
  "io.k8s.display-name": "NVIDIA Driver Container",
  "name": "NVIDIA Driver Container",
  "org.opencontainers.image.base.name": "docker.io/library/ubuntu",
  "org.opencontainers.image.created": "2026-08-17T20:08:27Z",
  "org.opencontainers.image.description": "Provision the NVIDIA driver through containers",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "181ac401f19e34000eb87ddb041a6ba99125e23b",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/gpu-driver-container.git",
  "org.opencontainers.image.title": "NVIDIA Driver Container",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "580.178.04-ubuntu24.04",
  "release": "N/A",
  "summary": "Provision the NVIDIA driver through containers",
  "vcs-ref": "181ac401f19e34000eb87ddb041a6ba99125e23b",
  "vendor": "NVIDIA",
  "version": "580.178.04"
}
```
