### PR TITLE
fix: Dead no-op `true` at start of `_remove_prerequisites`

### DIFF
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -192,7 +192,7 @@ _install_prerequisites() (
 
 # Cleanup the prerequisites installed above.
 _remove_prerequisites() {
-    true
+    echo "Removing installed kernel prerequisites..."
     if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
         dnf -q -y remove kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION} > /dev/null
         # TODO remove module files not matching an existing driver package.


### PR DESCRIPTION
This PR addresses the following issue in `rhel9/nvidia-driver`: Dead no-op `true` at start of `_remove_prerequisites`.

## Changes
- `rhel9/nvidia-driver`: Dead no-op `true` at start of `_remove_prerequisites`.

## Details
```diff
--- a/rhel9/nvidia-driver
+++ b/rhel9/nvidia-driver
@@ -1,8 +1,8 @@
-# Cleanup the prerequisites installed above.
-_remove_prerequisites() {
-    true
-    if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
-        dnf -q -y remove kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION} > /dev/null
-        # TODO remove module files not matching an existing driver package.
-    fi
-}
+# Cleanup the prerequisites installed above.
+_remove_prerequisites() {
+    echo "Removing installed kernel prerequisites..."
+    if [ "${PACKAGE_TAG:-}" != "builtin" ]; then
+        dnf -q -y remove kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION} > /dev/null
+        # TODO remove module files not matching an existing driver package.
+    fi
+}
```

## Tests
- `tests/test_remove_prerequisites.sh`

```diff
--- /dev/null
+++ b/tests/test_remove_prerequisites.sh
@@ -0,0 +1,22 @@
+#!/bin/bash
+# Static regression test for the dead no-op in _remove_prerequisites.
+set -eu
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+DRIVER_SCRIPT="${SCRIPT_DIR}/../rhel9/nvidia-driver"
+
+body=$(awk '/^_remove_prerequisites\(\) \{/,/^\}/' "${DRIVER_SCRIPT}")
+
+# Ensure the function no longer starts with a bare no-op 'true'.
+first_inner=$(echo "${body}" | sed -n '2p')
+if echo "${first_inner}" | grep -qE '^[[:space:]]*true[[:space:]]*$'; then
+    echo "FAIL: _remove_prerequisites still begins with dead no-op 'true'" >&2
+    exit 1
+fi
+
+# Ensure a meaningful status message replaced the no-op.
+if ! echo "${body}" | grep -qF 'echo "Removing installed kernel prerequisites..."'; then
+    echo "FAIL: expected status message not found in _remove_prerequisites" >&2
+    exit 1
+fi
+
+echo "PASS"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).