### PR TITLE
Guard unzboot copy by arch in ocp_dtk_entrypoint, amd64 doesn't have the binary

### DIFF
--- a/rhel10/ocp_dtk_entrypoint
+++ b/rhel10/ocp_dtk_entrypoint
@@ -39,9 +39,15 @@ nv-ctr-run-with-dtk() {
            /usr/local/bin/nvidia-driver \
            /usr/local/bin/common.sh \
            /usr/local/bin/extract-vmlinux \
-           /usr/bin/unzboot \
            /drivers \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
+
+        # unzboot is only built/installed on aarch64 (see install.sh); it doesn't
+        # exist on amd64 images, so only copy it there.
+        DRIVER_ARCH=${TARGETARCH/amd64/x86_64} && DRIVER_ARCH=${DRIVER_ARCH/arm64/aarch64}
+        if [[ "$DRIVER_ARCH" == "aarch64" ]]; then
+          cp /usr/bin/unzboot "$DRIVER_TOOLKIT_SHARED_DIR/"
+        fi
 
         if [[ -f "/usr/local/bin/vgpu-util" ]]; then
           cp /usr/local/bin/vgpu-util "$DRIVER_TOOLKIT_SHARED_DIR/"
@@ -172,8 +178,11 @@ dtk-build-driver() {
        "$DRIVER_TOOLKIT_SHARED_DIR/nvidia-driver" \
        "$DRIVER_TOOLKIT_SHARED_DIR/common.sh" \
        "$DRIVER_TOOLKIT_SHARED_DIR/extract-vmlinux" \
-       "$DRIVER_TOOLKIT_SHARED_DIR/unzboot" \
        "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
+
+    if [[ "$DRIVER_ARCH" == "aarch64" ]]; then
+      cp -v "$DRIVER_TOOLKIT_SHARED_DIR/unzboot" "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
+    fi
 
     if [[ -f "$DRIVER_TOOLKIT_SHARED_DIR/vgpu-util" ]]; then
       cp -v "$DRIVER_TOOLKIT_SHARED_DIR/vgpu-util" "$DRIVER_TOOLKIT_SHARED_DIR/bin"


### PR DESCRIPTION
Fixes #984.

`install.sh` only builds/installs `unzboot` on aarch64 (EPEL, zboot kernels). `ocp_dtk_entrypoint`'s shared-dir prep copied it unconditionally, so DTK mode crash-loops on amd64 before any build starts:

```
cp: cannot stat '/usr/bin/unzboot': No such file or directory
```

Guards both copy sites (the initial shared-dir prep in `nv-ctr-run-with-dtk`, and the later bin staging in `dtk-build-driver` which already has `$DRIVER_ARCH` computed) behind an aarch64 check, using the same `TARGETARCH`/`DRIVER_ARCH` normalization already used elsewhere in this file and in `install.sh`.

Verified by extracting both changed blocks and running them under bash with `TARGETARCH` set to each value: amd64 skips the copy cleanly with no missing-file error, arm64 with a real file present still copies it correctly.