### PR TITLE
Guard unzboot copy by arch in rhel10 DTK entrypoint

### DIFF
--- a/rhel10/ocp_dtk_entrypoint
+++ b/rhel10/ocp_dtk_entrypoint
@@ -39,9 +39,12 @@ nv-ctr-run-with-dtk() {
            /usr/local/bin/nvidia-driver \
            /usr/local/bin/common.sh \
            /usr/local/bin/extract-vmlinux \
-           /usr/bin/unzboot \
            /drivers \
            "$DRIVER_TOOLKIT_SHARED_DIR/"
+
+        if [[ "${TARGETARCH:-}" == "arm64" ]]; then
+          cp /usr/bin/unzboot "$DRIVER_TOOLKIT_SHARED_DIR/"
+        fi
 
         if [[ -f "/usr/local/bin/vgpu-util" ]]; then
           cp /usr/local/bin/vgpu-util "$DRIVER_TOOLKIT_SHARED_DIR/"
@@ -172,8 +175,11 @@ dtk-build-driver() {
        "$DRIVER_TOOLKIT_SHARED_DIR/nvidia-driver" \
        "$DRIVER_TOOLKIT_SHARED_DIR/common.sh" \
        "$DRIVER_TOOLKIT_SHARED_DIR/extract-vmlinux" \
-       "$DRIVER_TOOLKIT_SHARED_DIR/unzboot" \
        "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
+
+    if [[ "$DRIVER_ARCH" == "aarch64" ]]; then
+      cp -v "$DRIVER_TOOLKIT_SHARED_DIR/unzboot" "${DRIVER_TOOLKIT_SHARED_DIR}/bin"
+    fi
 
     if [[ -f "$DRIVER_TOOLKIT_SHARED_DIR/vgpu-util" ]]; then
       cp -v "$DRIVER_TOOLKIT_SHARED_DIR/vgpu-util" "$DRIVER_TOOLKIT_SHARED_DIR/bin"


### PR DESCRIPTION
Fixes #984.

`install.sh` only installs `/usr/bin/unzboot` when `DRIVER_ARCH` is `aarch64` (RHEL10 arm64 kernel images use the zboot format, per the comment at rhel10/install.sh:56). `ocp_dtk_entrypoint` copies it unconditionally on both the producer side (line ~42, shared-dir prep) and the consumer side (line ~178, DTK-side `bin/` staging), so on amd64 the DTK path fails before any build starts:

```
cp: cannot stat '/usr/bin/unzboot': No such file or directory
```

Guarded both copies by architecture: `$TARGETARCH == "arm64"` on the producer side (that's the only arch signal available at that point in the script), and `$DRIVER_ARCH == "aarch64"` on the consumer side, matching the variable already computed there a few lines earlier. Neither guard changes behavior on arm64/aarch64, unzboot still gets copied on both sides exactly as before.

**Verification.** No RHEL10/OCP DTK environment available to run this end to end, so I simulated both code paths directly against fake files standing in for the real ones: on amd64 the copy block now completes with no unzboot present and no error (previously reproduced the exact reported failure); on arm64/aarch64 unzboot is still correctly copied on both sides. Ran `bash -n` for a syntax check, clean.